### PR TITLE
extension load order

### DIFF
--- a/DoomLauncher/Adapters/GameFilePlayAdapter.cs
+++ b/DoomLauncher/Adapters/GameFilePlayAdapter.cs
@@ -7,15 +7,14 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Windows.Forms;
 
 namespace DoomLauncher
 {
     public class GameFilePlayAdapter
     {
         public event EventHandler ProcessExited;
+
+        private static string[] s_dehExtensions = new string[] { ".deh", ".bex" }; //future - should be configurable
 
         public GameFilePlayAdapter()
         {
@@ -88,9 +87,7 @@ namespace DoomLauncher
                 if (!HandleGameFile(loadFile, launchFiles, gameFileDirectory, tempDirectory, sourcePortData, true)) return null;
             }
 
-            string[] extensions = sourcePortData.SupportedExtensions.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-            launchFiles = SortParameters(launchFiles, extensions).ToList();
-
+            launchFiles = SortParameters(launchFiles).ToList();
             BuildLaunchString(sb, sourcePort, launchFiles);
 
             if (Map != null)
@@ -222,19 +219,16 @@ namespace DoomLauncher
 
         private void BuildLaunchString(StringBuilder sb, ISourcePort sourcePort, List<string> files)
         {
-            string[] dehExt = new string[] { ".deh", ".bex" }; //future - should be configurable
             List<string> dehFiles = new List<string>();
 
             if (files.Count > 0)
             {
                 sb.Append(sourcePort.FileParameter(new SpData()));
-                //if (!string.IsNullOrEmpty(sourcePort.FileOption))
-                //    sb.Append(string.Concat(" ", sourcePort.FileOption, " ")); //" -file "
 
                 foreach (string str in files)
                 {
                     FileInfo fi = new FileInfo(str);
-                    if (!dehExt.Contains(fi.Extension.ToLower()))
+                    if (!s_dehExtensions.Contains(fi.Extension.ToLower()))
                         sb.Append(string.Format("\"{0}\" ", str));
                     else
                         dehFiles.Add(str);
@@ -317,11 +311,21 @@ namespace DoomLauncher
             ProcessExited?.Invoke(this, new EventArgs());
         }
 
-        private IEnumerable<string> SortParameters(IEnumerable<string> parameters, string[] extensionOrder)
+        // Take .deh and .bex files and put them together so they cane be put in the same parameter
+        private IEnumerable<string> SortParameters(IEnumerable<string> parameters)
         {
-            List<string> ret = new List<string>();
-            Array.ForEach(extensionOrder, x => ret.AddRange(parameters.Where(y => y.ToLower().Contains(x.ToLower()))));
-            return ret;
+            List<string> dehFiles = new List<string>();
+
+            foreach(string file in parameters)
+            {
+                foreach (string deh in s_dehExtensions)
+                {
+                    if (Path.GetExtension(file).Equals(deh, StringComparison.OrdinalIgnoreCase))
+                        dehFiles.Add(file);
+                }
+            }
+
+            return parameters.Except(dehFiles).Union(dehFiles).ToList();
         }
     }
 }

--- a/UnitTest/Tests/TestPlayAdapter.cs
+++ b/UnitTest/Tests/TestPlayAdapter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using DoomLauncher;
 using System.IO;
 using System.IO.Compression;
@@ -94,7 +93,7 @@ namespace UnitTest.Tests
             adapter.ExtractFiles = false;
             LauncherPath gameFilePath = new LauncherPath("GameFiles");
             LauncherPath tempPath = new LauncherPath("Temp");
-            string launch = adapter.GetLaunchParameters(gameFilePath, tempPath, GetTestFile(), GetTestPort(".wad,.deh"), false);
+            adapter.GetLaunchParameters(gameFilePath, tempPath, GetTestFile(), GetTestPort(".wad,.deh"), false);
 
             Assert.IsFalse(File.Exists(Path.Combine(tempPath.GetFullPath(), "test1.wad")));
             Assert.IsFalse(File.Exists(Path.Combine(tempPath.GetFullPath(), "test1.deh")));
@@ -181,10 +180,10 @@ namespace UnitTest.Tests
             GameFilePlayAdapter adapter = new GameFilePlayAdapter();
             adapter.AdditionalFiles = GetTestFiles().Skip(1).ToArray();
 
-            string launch = adapter.GetLaunchParameters(gameFilePath, tempPath, GetTestFile(), GetTestPort(".wad,.deh"), false);
+            string launch = adapter.GetLaunchParameters(gameFilePath, tempPath, GetTestFile(), GetTestPort(".wad,.pk3,.deh"), false);
 
             //-file parameters should be together, then -deh files should be together
-            string check = string.Format("-file \"{0}\\Temp\\test2.wad\" \"{0}\\Temp\\test3.wad\" \"{0}\\Temp\\test4.wad\" \"{0}\\Temp\\test1.wad\"  -deh \"{0}\\Temp\\test2.deh\" \"{0}\\Temp\\test3.deh\" \"{0}\\Temp\\test4.deh\" \"{0}\\Temp\\test1.deh\" ",
+            string check = string.Format(" -file \"{0}\\Temp\\test2.wad\" \"{0}\\Temp\\test2.pk3\" \"{0}\\Temp\\test3.wad\" \"{0}\\Temp\\test3.pk3\" \"{0}\\Temp\\test4.wad\" \"{0}\\Temp\\test4.pk3\" \"{0}\\Temp\\test1.wad\" \"{0}\\Temp\\test1.pk3\"  -deh \"{0}\\Temp\\test2.deh\" \"{0}\\Temp\\test3.deh\" \"{0}\\Temp\\test4.deh\" \"{0}\\Temp\\test1.deh\" ",
                 Directory.GetCurrentDirectory());
             Assert.AreEqual(check.Trim(), launch.Trim());
 
@@ -348,7 +347,7 @@ namespace UnitTest.Tests
 
         private static void CreateTestPathedFile()
         {
-            string filename = string.Format(@"GameFiles\testpathed.zip");
+            string filename = @"GameFiles\testpathed.zip";
             if (File.Exists(filename))
                 File.Delete(filename);
 
@@ -365,7 +364,7 @@ namespace UnitTest.Tests
         {
             for (int i = 1; i < 5; i++)
             {
-                string[] files = new string[] { string.Format("test{0}.wad", i), string.Format("test{0}.deh", i), string.Format("test{0}.txt", i) };
+                string[] files = new string[] { string.Format("test{0}.wad", i), string.Format("test{0}.deh", i), string.Format("test{0}.pk3", i), string.Format("test{0}.txt", i) };
 
                 string filename = string.Format(@"GameFiles\test{0}.zip", i);
                 if (File.Exists(filename))


### PR DESCRIPTION
separate .deh and .bex files specifically instead of sorting all parameters to keep -file parameters in original order that have different extensions (.wad, .pk3, pk7, etc)