### PR TITLE
fix problems with WindowState maximized being saved

### DIFF
--- a/DoomLauncher/Forms/MainForm_Init.cs
+++ b/DoomLauncher/Forms/MainForm_Init.cs
@@ -382,17 +382,32 @@ namespace DoomLauncher
                 //Only set location and window state if the location is valid, either way we always set Width, Height, and splitter values
                 if (ValidatePosition(AppConfiguration))
                 {
-                    StartPosition = FormStartPosition.Manual;
-                    Location = new Point(AppConfiguration.AppX, AppConfiguration.AppY);
-
                     WindowState = AppConfiguration.WindowState;
+
+                    if (WindowState != FormWindowState.Maximized)
+                    {
+                        StartPosition = FormStartPosition.Manual;
+                        Location = new Point(AppConfiguration.AppX, AppConfiguration.AppY);
+                    }
                 }
+
+                // Save the height and set after splitter, otherwise splitter resizing will be incorrect
+                int saveWidth = Width;
+                int saveHeight = Height;
 
                 Width = AppConfiguration.AppWidth;
                 Height = AppConfiguration.AppHeight;
-
+                
                 splitTopBottom.SplitterDistance = AppConfiguration.SplitTopBottom;
                 splitLeftRight.SplitterDistance = AppConfiguration.SplitLeftRight;
+
+                // If the app was closed in the maximized state then the width and height are maxed out
+                // This causes the window to take up the full screen even when set to normal state
+                if (WindowState == FormWindowState.Maximized)
+                {
+                    Width = saveWidth;
+                    Height = saveHeight;
+                }
             }
             catch (DirectoryNotFoundException ex)
             {


### PR DESCRIPTION
if the saved window state is Maximized do not set the saved width/height so setting back to normal will use windows defaults
otherwise the window will still take up the whole screen