### PR TITLE
only reset handler if there is demo selected for play and there is a parser available to select additional files

### DIFF
--- a/DoomLauncher/Forms/PlayForm.cs
+++ b/DoomLauncher/Forms/PlayForm.cs
@@ -636,9 +636,6 @@ namespace DoomLauncher
 
         private void HandleDemoChange()
         {
-            m_handler.Reset();
-            SetAdditionalFiles(true);
-
             if (chkDemo.Checked && cmbDemo.SelectedItem != null)
             {
                 var file = cmbDemo.SelectedItem as IFileData;
@@ -646,6 +643,9 @@ namespace DoomLauncher
 
                 if (parser != null)
                 {
+                    m_handler.Reset();
+                    SetAdditionalFiles(true);
+
                     string[] requiredFiles = parser.GetRequiredFiles();
                     List<string> unavailable = new List<string>();
                     List<IGameFile> iwads = new List<IGameFile>();


### PR DESCRIPTION
Fix for when a user removes additional files from a source in a profile, but coming back adds them back in.

A user can have additional files configured in a source port. By default Doom Launcher will add them when the user selects that source port. If the user decides for that profile they do not want those files and removes them, when the form is reloaded it incorrectly resets and adds those files back in.