### PR TITLE
fix newly added IWADs showing in other tabs

### DIFF
--- a/DoomLauncher/Forms/MainForm.cs
+++ b/DoomLauncher/Forms/MainForm.cs
@@ -975,7 +975,7 @@ namespace DoomLauncher
                 fi.CopyTo(Path.Combine(AppConfiguration.GameFileDirectory.GetFullPath(), dlFile.FileName), true);
                 fi.Delete();
 
-                await SyncLocalDatabase(new string[] { fi.Name }, FileManagement.Managed);
+                await SyncLocalDatabase(new string[] { fi.Name }, FileManagement.Managed, true);
             }
             catch (IOException)
             {
@@ -1325,10 +1325,10 @@ namespace DoomLauncher
             switch (type)
             {
                 case AddFileType.GameFile:
-                    await SyncLocalDatabase(files, fileManagement);
+                    await SyncLocalDatabase(files, fileManagement, true);
                     break;
                 case AddFileType.IWad:
-                    await SyncLocalDatabase(files, fileManagement);
+                    await SyncLocalDatabase(files, fileManagement, false);
                     SyncIWads(fileAddResults);
                     break;
                 default:

--- a/DoomLauncher/Forms/MainForm_Sync.cs
+++ b/DoomLauncher/Forms/MainForm_Sync.cs
@@ -13,7 +13,7 @@ namespace DoomLauncher
     {
         private ProgressBarForm m_progressBarSync;
 
-        private async Task SyncLocalDatabase(string[] fileNames, FileManagement fileManagement)
+        private async Task SyncLocalDatabase(string[] fileNames, FileManagement fileManagement, bool updateViews)
         {
             if (m_progressBarSync == null)
             {
@@ -25,13 +25,16 @@ namespace DoomLauncher
 
             ProgressBarEnd(m_progressBarSync);
             m_progressBarSync = null;
-            SyncLocalDatabaseComplete(handler);
+            SyncLocalDatabaseComplete(handler, updateViews);
         }
 
-        void SyncLocalDatabaseComplete(SyncLibraryHandler handler)
+        void SyncLocalDatabaseComplete(SyncLibraryHandler handler, bool updateViews)
         {
-            UpdateLocal();
-            HandleTabSelectionChange();
+            if (updateViews)
+            {
+                UpdateLocal();
+                HandleTabSelectionChange();
+            }
 
             if (handler != null &&
                 (handler.InvalidFiles.Length > 0 || m_zdlInvalidFiles.Count > 0))
@@ -190,14 +193,8 @@ namespace DoomLauncher
                 }
             }
 
-            foreach (ITabView tab in m_tabHandler.TabViews)
-            {
-                if (tab is IWadTabViewCtrl)
-                {
-                    UpdateLocalTabData(tab);
-                    HandleSelectionChange(tab.GameFileViewControl, false);
-                }
-            }
+            UpdateLocal();
+            HandleTabSelectionChange();
         }
 
         private async void HandleSyncStatus()
@@ -232,7 +229,7 @@ namespace DoomLauncher
                     SyncLibraryHandler handler = await Task.Run(() => ExecuteSyncHandler(files.ToArray(), FileManagement.Managed));
 
                     ProgressBarEnd(m_progressBarSync);
-                    SyncLocalDatabaseComplete(handler);
+                    SyncLocalDatabaseComplete(handler, true);
                     break;
 
                 case SyncFileOption.Delete:


### PR DESCRIPTION
prevent SyncLocalDatabase from updating views when adding IWADs so the new IWADs do not incorrectly show up in the other views