### PR TITLE
add multiple files

### DIFF
--- a/DoomLauncher/Controls/BasicFileView.cs
+++ b/DoomLauncher/Controls/BasicFileView.cs
@@ -212,19 +212,27 @@ namespace DoomLauncher
         {
             List<IFileData> selectedFiles = GetSelectedFiles();
 
-            if (selectedFiles.Count > 0)
+            try
             {
-                IFileData file = selectedFiles.First();
+                if (selectedFiles.Count > 0)
+                {
+                    IFileData file = selectedFiles.First();
 
-                if (file.IsUrl)
-                {
-                    Process.Start(file.FileName);
+                    if (file.IsUrl)
+                    {
+                        Process.Start(file.FileName);
+                    }
+                    else
+                    {
+                        if (File.Exists(Path.Combine(DataDirectory.GetFullPath(), file.FileName)))
+                            Process.Start(Path.Combine(DataDirectory.GetFullPath(), file.FileName));
+                    }
                 }
-                else
-                {
-                    if (File.Exists(Path.Combine(DataDirectory.GetFullPath(), file.FileName)))
-                        Process.Start(Path.Combine(DataDirectory.GetFullPath(), file.FileName));
-                }
+            }
+            catch (Exception ex)
+            {
+                // This happens when windows doesn't recognize the file extension
+                MessageBox.Show(this, ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/DoomLauncher/Controls/GameFileAssociationView.cs
+++ b/DoomLauncher/Controls/GameFileAssociationView.cs
@@ -7,6 +7,7 @@ namespace DoomLauncher
 {
     public partial class GameFileAssociationView : UserControl
     {
+        public event EventHandler FileAdded;
         public event EventHandler FileDeleted;
         public event EventHandler FileOrderChanged;
         public event EventHandler<RequestScreenshotsEventArgs> RequestScreenshots;
@@ -163,7 +164,7 @@ namespace DoomLauncher
         private void HandleDelete()
         {
             if (CurrentView != null && CurrentView.DeleteAllowed && CurrentView.Delete())
-                FileDeleted?.Invoke(this, new EventArgs());
+                FileDeleted?.Invoke(this, EventArgs.Empty);
         }
 
         private void addFileToolStripMenuItem_Click(object sender, EventArgs e)
@@ -174,7 +175,10 @@ namespace DoomLauncher
         private void HandleAdd()
         {
             if (CurrentView != null && CurrentView.NewAllowed && CurrentView.New())
+            {
+                FileAdded?.Invoke(this, EventArgs.Empty);
                 SetData(m_gameFile);
+            }
         }
 
         private void editDetailsToolStripMenuItem_Click(object sender, EventArgs e)
@@ -209,7 +213,7 @@ namespace DoomLauncher
                 CurrentView.SetFileOrderFirst())
             {
                 SetData(m_gameFile);
-                FileOrderChanged?.Invoke(this, new EventArgs());
+                FileOrderChanged?.Invoke(this, EventArgs.Empty);
             }
         }
 
@@ -228,7 +232,7 @@ namespace DoomLauncher
             if (success)
             {
                 SetData(m_gameFile);
-                FileOrderChanged?.Invoke(this, new EventArgs());
+                FileOrderChanged?.Invoke(this, EventArgs.Empty);
             }
         }
 

--- a/DoomLauncher/Controls/ScreenshotView.cs
+++ b/DoomLauncher/Controls/ScreenshotView.cs
@@ -139,7 +139,12 @@ namespace DoomLauncher
 
             m_pictureBoxes.Clear();
 
-            for (int i = 0; i < 50; i++)
+            ExpandPictureBoxes(50);
+        }
+
+        private void ExpandPictureBoxes(int count)
+        {
+            for (int i = 0; i < count; i++)
                 m_pictureBoxes.Add(CreatePictureBox());
 
             ToolTip tt = new ToolTip();
@@ -150,13 +155,17 @@ namespace DoomLauncher
         public void SetScreenshots(List<IFileData> screenshots)
         {
             flpScreenshots.SuspendLayout();
-            List<PictureBox>.Enumerator enumerator = m_pictureBoxes.GetEnumerator();
 
             foreach (var pb in m_pictureBoxes)
                 pb.ImageLocation = string.Empty;
 
             m_screenshots = screenshots.ToList();
             m_lookup.Clear();
+
+            if (m_screenshots.Count > m_pictureBoxes.Count)
+                ExpandPictureBoxes(m_screenshots.Count - m_pictureBoxes.Count);
+
+            List<PictureBox>.Enumerator enumerator = m_pictureBoxes.GetEnumerator();
 
             foreach (IFileData screen in screenshots)
             {

--- a/DoomLauncher/Forms/MainForm.cs
+++ b/DoomLauncher/Forms/MainForm.cs
@@ -113,6 +113,13 @@ namespace DoomLauncher
             return null;
         }
 
+        private void ctrlAssociationView_FileAdded(object sender, EventArgs e)
+        {
+            IGameFileView view = GetCurrentViewControl();
+            view.UpdateGameFile(view.SelectedItem);
+            HandleSelectionChange(GetCurrentViewControl(), true);
+        }
+
         void ctrlAssociationView_FileDeleted(object sender, EventArgs e)
         {
             IGameFileView view = GetCurrentViewControl();

--- a/DoomLauncher/Forms/MainForm_Init.cs
+++ b/DoomLauncher/Forms/MainForm_Init.cs
@@ -461,6 +461,7 @@ namespace DoomLauncher
             m_downloadHandler = new DownloadHandler(AppConfiguration.TempDirectory, m_downloadView);
 
             ctrlAssociationView.Initialize(DataSourceAdapter, AppConfiguration);
+            ctrlAssociationView.FileAdded += ctrlAssociationView_FileAdded;
             ctrlAssociationView.FileDeleted += ctrlAssociationView_FileDeleted;
             ctrlAssociationView.FileOrderChanged += ctrlAssociationView_FileOrderChanged;
             ctrlAssociationView.RequestScreenshots += CtrlAssociationView_RequestScreenshots;


### PR DESCRIPTION
Allows user to select multiple files when adding files such as screenshots. Allow picture boxes in screenshot view to expand as they were previously limited.