### PR TITLE
Application now automatically resumes from last selected tab

### DIFF
--- a/DoomLauncher/Config/AppConfiguration.cs
+++ b/DoomLauncher/Config/AppConfiguration.cs
@@ -21,6 +21,7 @@ namespace DoomLauncher
         public static string ColumnConfigName => "ColumnConfig";
         public static string ScreenshotPreviewSizeName => "ScreenshotPreviewSize";
         public static string ItemsPerPageName => "ItemsPerPage";
+        public static string LastSelectedTab => "LastSelectedTab";
 
         public AppConfiguration(IDataSourceAdapter adapter)
         {
@@ -113,6 +114,7 @@ namespace DoomLauncher
                 FileManagement = (FileManagement)Enum.Parse(typeof(FileManagement), GetValue(config, "FileManagement"));
                 ItemsPerPage = Convert.ToInt32(GetValue(config, ItemsPerPageName));
                 DeleteScreenshotsAfterImport = Convert.ToBoolean(GetValue(config, "DeleteScreenshotsAfterImport"));
+                LastSelectedTabIndex = Convert.ToInt32(GetValue(config, LastSelectedTab));
 
                 var newType = (GameFileViewType)Enum.Parse(typeof(GameFileViewType), GetValue(config, "GameFileViewType"));
                 if (newType != GameFileViewType)
@@ -229,5 +231,6 @@ namespace DoomLauncher
         public GameFileViewType GameFileViewType { get; private set; }
         public int ItemsPerPage { get; set; }
         public bool DeleteScreenshotsAfterImport { get; set; }
+        public int LastSelectedTabIndex { get; set; }
     }
 }

--- a/DoomLauncher/Forms/MainForm.cs
+++ b/DoomLauncher/Forms/MainForm.cs
@@ -1058,6 +1058,7 @@ namespace DoomLauncher
 
                     tabView.GameFileViewControl.Focus();
                     tabView.GameFileViewControl.SetVisible(true);
+                    AppConfiguration.LastSelectedTabIndex = tabControl.SelectedIndex;
                     HandleSelectionChange(tabView.GameFileViewControl, false);
                 }
             }

--- a/DoomLauncher/Forms/MainForm_Config.cs
+++ b/DoomLauncher/Forms/MainForm_Config.cs
@@ -36,6 +36,7 @@ namespace DoomLauncher
 
                 UpdateConfig(config, ConfigType.AutoSearch.ToString("g"), chkAutoSearch.Checked.ToString());
                 UpdateConfig(config, AppConfiguration.ItemsPerPageName, AppConfiguration.ItemsPerPage.ToString());
+                UpdateConfig(config, AppConfiguration.LastSelectedTab, tabControl.SelectedIndex.ToString());
             }
         }
 

--- a/DoomLauncher/Forms/MainForm_Init.cs
+++ b/DoomLauncher/Forms/MainForm_Init.cs
@@ -464,6 +464,7 @@ namespace DoomLauncher
             ctrlAssociationView.FileDeleted += ctrlAssociationView_FileDeleted;
             ctrlAssociationView.FileOrderChanged += ctrlAssociationView_FileOrderChanged;
             ctrlAssociationView.RequestScreenshots += CtrlAssociationView_RequestScreenshots;
+            tabControl.SelectedIndex = AppConfiguration.LastSelectedTabIndex;
 
             m_splash.Close();
 


### PR DESCRIPTION
As per my enhancement suggestion (https://github.com/nstlaurent/DoomLauncher/issues/197) I implemented the feature to save the current tab on exit.

Currently, the user isn't allowed to opt-out of this, but adding an entry in the Settings window shouldn't take too much time.