### PR TITLE
My attempt to try and add IPK3 files to the IWAD file picker.

### DIFF
--- a/DoomLauncher/Forms/MainForm.cs
+++ b/DoomLauncher/Forms/MainForm.cs
@@ -1281,7 +1281,7 @@ namespace DoomLauncher
 
         private async Task HandleAddIWads()
         {
-            await HandleAddFiles(AddFileType.IWad, new string[] { "WAD" }, "Select IWADs");
+            await HandleAddFiles(AddFileType.IWad, new string[] { "WAD" "ipk3" }, "Select IWADs");
         }
 
         private void UpdateLocal()


### PR DESCRIPTION
Self explanatory.

It always bugged me how the IWAD file picker had no option for IPK3s when Doom Launcher doesn't seem to have any problems with them, this fixes that.

This has not been tested, because i don't have Visual Studio, so if there's any issues, please inform me.
