### PR TITLE
Tests won't fail on non-English locales when asserting DateTime values.

### DIFF
--- a/DoomLauncher/Statistics/StatFileScanner.cs
+++ b/DoomLauncher/Statistics/StatFileScanner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 
 namespace DoomLauncher
@@ -39,7 +40,7 @@ namespace DoomLauncher
             if (item.DataSourceProperty == "LevelTime") //speical case, need to split out ':' and calculate time
             {
                 string[] time = value.Split(new char[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
-                pi.SetValue(stats, (Convert.ToSingle(time[0]) * 60) + Convert.ToSingle(time[1]));
+                pi.SetValue(stats, (Convert.ToSingle(time[0], CultureInfo.InvariantCulture) * 60) + Convert.ToSingle(time[1], CultureInfo.InvariantCulture));
             }
             else
             {

--- a/DoomLauncher/TextFileParsers/IdGamesTextFileParser.cs
+++ b/DoomLauncher/TextFileParsers/IdGamesTextFileParser.cs
@@ -49,8 +49,10 @@ namespace DoomLauncher.TextFileParsers
 
         private bool ParseDate1(string date, string[] dateParseFormats, out DateTime dt)
         {
-            if (DateTime.TryParse(date, out dt))
+            if (DateTime.TryParse(date, CultureInfo.InvariantCulture, DateTimeStyles.None, out dt))
+            {
                 return true;
+            }   
             else if (DateTime.TryParseExact(date, dateParseFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out dt))
                 return true;
 

--- a/UnitTest/Tests/TestIdGamesFileParser.cs
+++ b/UnitTest/Tests/TestIdGamesFileParser.cs
@@ -1,6 +1,7 @@
 ﻿using DoomLauncher.TextFileParsers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Globalization;
 
 namespace UnitTest.Tests
 {
@@ -57,7 +58,7 @@ namespace UnitTest.Tests
                 "Release date: junk 5 April 2016 junk",
             };
 
-            DateTime assert = DateTime.Parse("4/5/2016");
+            DateTime assert = DateTime.Parse("4/5/2016", CultureInfo.InvariantCulture);
 
             foreach (string date in dates)
             {
@@ -82,14 +83,14 @@ namespace UnitTest.Tests
             parser.Parse(test);
 
             Assert.AreEqual("Onslaught DM 3 (v.1.1)", parser.Title);
-            Assert.AreEqual(DateTime.Parse("01/17/07"), parser.ReleaseDate);
+            Assert.AreEqual(DateTime.Parse("01/17/07", CultureInfo.InvariantCulture), parser.ReleaseDate);
             Assert.AreEqual("Hobomaster22, Ak-01", parser.Author); //Could be Author: or Authors:
             Assert.AreEqual("21 head to head deathmatch maps with faced paced action.  This is a 1on1 specific mapset. For FFA more than 4 players is not recommended.", parser.Description);
 
             test = test.Replace("AUTHORS", "AUTHOR");
             parser.Parse(test);
             Assert.AreEqual("Onslaught DM 3 (v.1.1)", parser.Title);
-            Assert.AreEqual(DateTime.Parse("01/17/07"), parser.ReleaseDate);
+            Assert.AreEqual(DateTime.Parse("01/17/07", CultureInfo.InvariantCulture), parser.ReleaseDate);
             Assert.AreEqual("Hobomaster22, Ak-01", parser.Author); //Could be Author: or Authors:
             Assert.AreEqual("21 head to head deathmatch maps with faced paced action.  This is a 1on1 specific mapset. For FFA more than 4 players is not recommended.", parser.Description);
 

--- a/UnitTest/Tests/TestSyncLibraryHandler.cs
+++ b/UnitTest/Tests/TestSyncLibraryHandler.cs
@@ -1,6 +1,7 @@
 ﻿using DoomLauncher;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -143,7 +144,7 @@ namespace UnitTest.Tests
             Assert.AreEqual("The Joy of Mapping #1", gameFile.Title);
             Assert.AreEqual("Jimmy & Various", gameFile.Author);
             Assert.IsTrue(gameFile.Description.StartsWith("This was a livestreamed communal mapping session"));
-            Assert.AreEqual(gameFile.ReleaseDate, DateTime.Parse("8/1/2016"));
+            Assert.AreEqual(gameFile.ReleaseDate, DateTime.Parse("8/1/2016", CultureInfo.InvariantCulture));
 
             File.Copy(Path.Combine("Resources", "uroburos.zip"), Path.Combine(s_filedir, file), true);
             handler.Execute(new string[] { file });
@@ -159,7 +160,7 @@ namespace UnitTest.Tests
             Assert.AreEqual("Uroburos", gameFile.Title);
             Assert.AreEqual("hobomaster22", gameFile.Author);
             Assert.IsTrue(gameFile.Description.StartsWith("A 1on1 map"));
-            Assert.AreEqual(gameFile.ReleaseDate, DateTime.Parse("3/5/2005"));
+            Assert.AreEqual(gameFile.ReleaseDate, DateTime.Parse("3/5/2005", CultureInfo.InvariantCulture));
         }
 
         [TestMethod]


### PR DESCRIPTION
As stated in issue #230, some tests would fail when building DoomLauncher on non-English locales. This commit fixes this by replacing the calls to DateTime.Parse(string) in unit tests to DateTime.Parse(string, IFormatProvider).