### PR TITLE
Fix crash by missing default colour

### DIFF
--- a/DoomLauncher/Controls/GameFileTile.cs
+++ b/DoomLauncher/Controls/GameFileTile.cs
@@ -138,7 +138,7 @@ namespace DoomLauncher
             m_new = gameFile.Downloaded.HasValue && (DateTime.Now - gameFile.Downloaded.Value).TotalHours < 24;
 
             var colorTag = tags.FirstOrDefault(x => x.HasColor);
-            if (colorTag != null)
+            if (colorTag != null && colorTag.Color != null)
                 m_titleColor = Color.FromArgb(colorTag.Color.Value);
             else
                 m_titleColor = SystemColors.WindowText;

--- a/DoomLauncher/Controls/TagEdit.cs
+++ b/DoomLauncher/Controls/TagEdit.cs
@@ -20,6 +20,7 @@ namespace DoomLauncher
             cmbColor.SelectedIndex = 1;
             cmbExclude.SelectedIndex = 1;
             cmbFavorite.SelectedIndex = 1;
+            m_color = Color.Black;
 
             Load += TagEdit_Load;
         }


### PR DESCRIPTION
Also added a 'prevent' in the tab display should existing bad data exists.

This is to fix issue #245 that I opened