### PR TITLE
Isolated tests

### DIFF
--- a/DoomLauncher/Adapters/DbDataSourceAdapter.cs
+++ b/DoomLauncher/Adapters/DbDataSourceAdapter.cs
@@ -286,7 +286,7 @@ namespace DoomLauncher
                 DataAccess.DbAdapter.CreateParameter("where1", fWhere ?? DBNull.Value )
             };
 
-            DataAccess.ExecuteNonQuery(string.Format(@"update GameFiles set {0} = @set1 where {1} = @where1", ftWhere.ToString("g"), ftSet.ToString("g")), parameters);
+            DataAccess.ExecuteNonQuery(string.Format(@"update GameFiles set {0} = @set1 where {1} = @where1", ftSet.ToString("g"), ftWhere.ToString("g")), parameters);
         }
 
         public void DeleteGameFile(IGameFile gameFile)

--- a/DoomLauncher/Adapters/DbDataSourceAdapter.cs
+++ b/DoomLauncher/Adapters/DbDataSourceAdapter.cs
@@ -27,10 +27,7 @@ namespace DoomLauncher
 
         public DbDataSourceAdapter(IDatabaseAdapter dbAdapter, string connectionString, bool outOfDateDatabase)
         {
-            DbAdapter = dbAdapter;
-            ConnectionString = connectionString;
             m_outOfDateDatabase = outOfDateDatabase;
-
             DataAccess = new DataAccess(dbAdapter, connectionString);
         }
 
@@ -839,9 +836,7 @@ namespace DoomLauncher
             return DataAccess.ExecuteSelect($"pragma table_info({tableName});").Tables[0];
         }
 
-        private DataAccess DataAccess { get; set; }
-        public IDatabaseAdapter DbAdapter { get; private set; }
-        public string ConnectionString { get; private set; }
+        public DataAccess DataAccess { get; private set; }
 
         private readonly bool m_outOfDateDatabase;
     }

--- a/README.adoc
+++ b/README.adoc
@@ -53,6 +53,11 @@ changes work before submitting them.
 Doom Launcher currently supports Windows 7 and later. Mac and Linux are
 unsupported.
 
+In order to build the Setup module for Visual Studio 2022, you may need to separately install 
+support for Installer projects: 
+https://marketplace.visualstudio.com/items?itemName=VisualStudioClient.MicrosoftVisualStudio2022InstallerProjects 
+
+
 == Development Tools
 
 SQLite Browser. Great tool for viewing and editing the DoomLauncher.sqlite database: 

--- a/UnitTest/TestInit.cs
+++ b/UnitTest/TestInit.cs
@@ -11,13 +11,11 @@ namespace UnitTest
         [AssemblyInitialize()]
         public static void TestInitialize(TestContext testContext)
         {
-            string dataSource = Path.Combine(Directory.GetCurrentDirectory(), "DoomLauncher.sqlite");
             DbDataSourceAdapter adapter = (DbDataSourceAdapter)TestUtil.CreateAdapter();
-            DataAccess access = new DataAccess(new SqliteDatabaseAdapter(), DbDataSourceAdapter.CreateConnectionString(dataSource));
 
             DataCache.Instance.Init(adapter);
 
-            VersionHandler versionHandler = new VersionHandler(access, adapter, new AppConfiguration(adapter));
+            VersionHandler versionHandler = new VersionHandler(adapter.DataAccess, adapter, new AppConfiguration(adapter));
             versionHandler.HandleVersionUpdate();
         }
     }

--- a/UnitTest/Tests/TestFile.cs
+++ b/UnitTest/Tests/TestFile.cs
@@ -22,7 +22,8 @@ namespace UnitTest.Tests
         [TestCleanup]
         public void CleanDatabase()
         {
-            TestUtil.CleanDatabase(database);
+            var dataAccess = ((DbDataSourceAdapter)database).DataAccess;
+            dataAccess.ExecuteNonQuery("delete from Files");
         }
 
         [TestMethod]

--- a/UnitTest/Tests/TestFile.cs
+++ b/UnitTest/Tests/TestFile.cs
@@ -11,125 +11,491 @@ namespace UnitTest.Tests
     [TestClass]
     public class TestFile
     {
-        private static List<IFileData> CreateTestFiles()
-        {
-            List<IFileData> ret = new List<IFileData>();
-            int id = 1;
-            for (int j = 1; j < 4; j++)
-            {
-                for (int i = 0; i < 4; i++)
-                {
-                    ret.Add(new FileData
-                    {
-                        FileID = id,
-                        FileName = id.ToString(),
-                        FileTypeID = (FileType)j,
-                        FileOrder = id,
-                        Description = id.ToString(),
-                        DateCreated = DateTime.Parse("1/1/2017"),
-                        GameFileID = id % 3,
-                        SourcePortID = id,
-                        OriginalFileName = id.ToString(),
-                        OriginalFilePath = id.ToString(),
-                        UserTitle = id.ToString(),
-                        UserDescription = id.ToString(),
-                        Map = id.ToString()
-                    });
-                    id++;
-                }
-            }
+        private IDataSourceAdapter database;
 
-            return ret;
+        [TestInitialize]
+        public void Initialize()
+        {
+            database = TestUtil.CreateAdapter();
         }
 
+        [TestCleanup]
+        public void CleanDatabase()
+        {
+            TestUtil.CleanDatabase(database);
+        }
 
         [TestMethod]
-        public void TestFiles()
+        public void GetFiles_GameFile_ReturnsMatchingFiles()
         {
-            TestInsertFile();
-            TestGetFile();
-            TestUpdateFile();
-            TestDeleteFile();
-        }
 
-        public void TestInsertFile()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var testFiles = CreateTestFiles();
+            var gameFileId = 37;
 
-            foreach (var file in testFiles)
-                adapter.InsertFile(file);
-        }
-
-        public void TestGetFile()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var testFiles = CreateTestFiles();
-
-            var gameFileIDs = testFiles.Select(x => x.GameFileID).Distinct();
-            foreach(var id in gameFileIDs)
-            {
-                var dbFiles = adapter.GetFiles(new DoomLauncher.DataSources.GameFile() { GameFileID = id });
-                Assert.IsTrue(testFiles.Count(x => x.GameFileID == id) == dbFiles.Count());
-                
-                foreach(var dbFile in dbFiles)
-                    Assert.IsTrue(TestUtil.AllFieldsEqual(dbFile, testFiles.First(x => x.FileID == dbFile.FileID)));
-
-                for(int i = 1; i < 4; i++)
+            var file1 = 
+                new FileData 
                 {
-                    dbFiles = adapter.GetFiles(new DoomLauncher.DataSources.GameFile() { GameFileID = id }, (FileType)i);
+                    FileName = "Rabbits.txt",
+                    FileTypeID = FileType.SaveGame,
+                    FileOrder = 33,
+                    Description = "Furry creatures",
+                    DateCreated = DateTime.Parse("2/1/2018"),
+                    GameFileID = gameFileId,
+                    SourcePortID = 2,
+                    OriginalFileName = "Bunnies.txt",
+                    OriginalFilePath = "lagomorphs\\Bunnies.txt",
+                    UserTitle = "All about rabbits",
+                    UserDescription = "I didn't understand it",
+                    Map = "zzz"
+                };
 
-                    foreach (var dbFile in dbFiles)
-                        Assert.IsNotNull(testFiles.FirstOrDefault(x => x.FileID == dbFile.FileID && x.FileTypeID == (FileType)i));
-                }
-            }
+            var file2 =
+                new FileData
+                {
+                    FileName = "unreal.txt",
+                    FileTypeID = FileType.TileImage,
+                    FileOrder = 2,
+                    Description = "Tim Sweeney's revenge",
+                    DateCreated = DateTime.Parse("5/6/1996"),
+                    GameFileID = gameFileId,
+                    SourcePortID = 8,
+                    OriginalFileName = "unrealio_dealio.txt",
+                    OriginalFilePath = "whynot\\unrealio_dealio.txt",
+                    UserTitle = "The truth about Unreal Tournament",
+                    UserDescription = "A gripping tale",
+                    Map = "aaa"
+                };
+
+            var wrongFile =
+                new FileData
+                {
+                    FileName = "wrong.txt",
+                    FileTypeID = FileType.Unknown,
+                    FileOrder = 2,
+                    Description = "Wrong file",
+                    DateCreated = DateTime.Parse("1/7/1991"),
+                    GameFileID = -1,
+                    SourcePortID = 9,
+                    OriginalFileName = "wrongity_wrong.txt",
+                    OriginalFilePath = "bad\\wrongity_wrong.txt",
+                    UserTitle = "It's wrong",
+                    UserDescription = "Don't use this one",
+                    Map = "666"
+                };
+
+            database.InsertFile(file1);
+            database.InsertFile(file2);
+            database.InsertFile(wrongFile);
+
+            var files = database.GetFiles(new GameFile { GameFileID = gameFileId });
+            Assert.AreEqual(2, files.Count());
+
+            var retrieved1 = files.Where(x => x.FileName.Equals(file1.FileName)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(file1, retrieved1, "FileID"));
+
+            var retrieved2 = files.Where(x => x.FileName.Equals(file2.FileName)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(file2, retrieved2, "FileID"));
+
+            Assert.AreEqual(0, files.Where(x => x.FileName.Equals(wrongFile.FileName)).Count());
         }
 
-        public void TestUpdateFile()
+        [TestMethod]
+        public void GetFiles_GameFile_FileType_ReturnsMatchingFiles()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var files = adapter.GetFiles(new DoomLauncher.DataSources.GameFile() { GameFileID = 1 });
+            var gameFileId = 999;
+            FileType fileType = FileType.Thumbnail;
 
-            foreach(var file in files)
-            {
-                //we only update these three fields
-                file.SourcePortID += 100;
-                file.Description += "100";
-                file.FileOrder += 100;
+            var file1 =
+                new FileData
+                {
+                    FileName = "red.txt",
+                    FileTypeID = fileType,
+                    FileOrder = 24,
+                    Description = "A redulent color",
+                    DateCreated = DateTime.Parse("9/3/2033"),
+                    GameFileID = gameFileId,
+                    SourcePortID = 2,
+                    OriginalFileName = "hongse.txt",
+                    OriginalFilePath = "colors\\hongse.txt",
+                    UserTitle = "It's another color",
+                    UserDescription = "Primary color, a bit angry",
+                    Map = "yyy"
+                };
 
-                adapter.UpdateFile(file);
-            }
+            var wrongGameIdFile =
+                new FileData
+                {
+                    FileName = "wrong.txt",
+                    FileTypeID = fileType,
+                    FileOrder = 2,
+                    Description = "Wrong file",
+                    DateCreated = DateTime.Parse("1/7/1991"),
+                    GameFileID = 444,
+                    SourcePortID = 9,
+                    OriginalFileName = "wrongity_wrong.txt",
+                    OriginalFilePath = "bad\\wrongity_wrong.txt",
+                    UserTitle = "Wrong game ID",
+                    UserDescription = "Don't use this one",
+                    Map = "666"
+                };
 
-            var newFiles = adapter.GetFiles(new GameFile() { GameFileID = 1 });
+            var wrongFileTypeFile =
+                new FileData
+                {
+                    FileName = "false.txt",
+                    FileTypeID = FileType.SaveGame,
+                    FileOrder = 3,
+                    Description = "False, tricksy file",
+                    DateCreated = DateTime.Parse("3/8/2000"),
+                    GameFileID = gameFileId,
+                    SourcePortID = 8,
+                    OriginalFileName = "this_aint_it.txt",
+                    OriginalFilePath = "incorrect\\this_aint_it.txt",
+                    UserTitle = "Wrong file type",
+                    UserDescription = "Absolutely not",
+                    Map = "667"
+                };
 
-            foreach(var file in files)
-            {
-                var newFile = newFiles.FirstOrDefault(x => x.FileID == file.FileID);
-                Assert.IsNotNull(newFile);
-                Assert.IsTrue(TestUtil.AllFieldsEqual(file, newFile));
-            }
+            database.InsertFile(file1);
+            database.InsertFile(wrongGameIdFile);
+            database.InsertFile(wrongFileTypeFile);
+
+            var files = database.GetFiles(new GameFile { GameFileID = gameFileId }, fileType);
+
+            Assert.AreEqual(1, files.Count());
+
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(file1, files.First(), "FileID"));
         }
 
+        [TestMethod]
+        public void GetFiles_NoArgs_ReturnsAllFiles()
+        {
+            var file1 =
+                new FileData
+                {
+                    FileName = "hippo.txt",
+                    FileTypeID = FileType.Demo,
+                    FileOrder = 3,
+                    Description = "river horse",
+                    DateCreated = DateTime.Parse("6/9/2033"),
+                    GameFileID = 555,
+                    SourcePortID = 2,
+                    OriginalFileName = "hippopotamus.txt",
+                    OriginalFilePath = "animals\\hippopotamus.txt",
+                    UserTitle = "I like hippos",
+                    UserDescription = "They are very hungry",
+                    Map = "hjkl"
+                };
+
+            var file2 =
+                new FileData
+                {
+                    FileName = "giraffe.txt",
+                    FileTypeID = FileType.Screenshot,
+                    FileOrder = 9,
+                    Description = "long neck deer",
+                    DateCreated = DateTime.Parse("1/1/1992"),
+                    GameFileID = 553,
+                    SourcePortID = 6,
+                    OriginalFileName = "giraffe_pattern.txt",
+                    OriginalFilePath = "animals\\giraffe_pattern.txt",
+                    UserTitle = "Long neck giraffe",
+                    UserDescription = "Why are their necks so long",
+                    Map = "aaa"
+                };
+
+            database.InsertFile(file1);
+            database.InsertFile(file2);
+
+            var files = database.GetFiles();
+
+            Assert.AreEqual(2, files.Count());
+
+            var retrieved1 = files.Where(x => x.FileName.Equals(file1.FileName)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(file1, retrieved1, "FileID"));
+
+            var retrieved2 = files.Where(x => x.FileName.Equals(file2.FileName)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(file2, retrieved2, "FileID"));
+        }
+
+        [TestMethod]
+        public void GetFiles_FileType_ReturnsMatchingFiles()
+        {
+            var file1 =
+                new FileData
+                {
+                    FileName = "cacodemon.txt",
+                    FileTypeID = FileType.Demo,
+                    FileOrder = 1,
+                    Description = "red floaty boi",
+                    DateCreated = DateTime.Parse("1/2/2011"),
+                    GameFileID = 236,
+                    SourcePortID = 2,
+                    OriginalFileName = "caco.txt",
+                    OriginalFilePath = "monsters\\caco.txt",
+                    UserTitle = "The fanciest demon",
+                    UserDescription = "Three double shotty hits on a good day",
+                    Map = "yyy"
+                };
+
+            var file2 =
+                new FileData
+                {
+                    FileName = "imp.txt",
+                    FileTypeID = FileType.Demo,
+                    FileOrder = 1,
+                    Description = "brown fella",
+                    DateCreated = DateTime.Parse("3/6/1998"),
+                    GameFileID = 353,
+                    SourcePortID = 8,
+                    OriginalFileName = "impy.txt",
+                    OriginalFilePath = "monsters\\impy.txt",
+                    UserTitle = "One shotty blast",
+                    UserDescription = "Two if you miss",
+                    Map = "yyy"
+                };
+
+            var wrongFile =
+                new FileData
+                {
+                    FileName = "oops.txt",
+                    FileTypeID = FileType.Thumbnail,
+                    FileOrder = 8,
+                    Description = "wrong file type",
+                    DateCreated = DateTime.Parse("5/3/1997"),
+                    GameFileID = 222,
+                    SourcePortID = 9,
+                    OriginalFileName = "whoops.txt",
+                    OriginalFilePath = "ohno\\whoops.txt",
+                    UserTitle = "Very much the wrong one",
+                    UserDescription = "no way",
+                    Map = "www"
+                };
+
+            database.InsertFile(file1);
+            database.InsertFile(file2);
+            database.InsertFile(wrongFile);
+
+            var files = database.GetFiles(FileType.Demo);
+
+            Assert.AreEqual(2, files.Count());
+
+            var retrieved1 = files.Where(x => x.FileName.Equals(file1.FileName)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(file1, retrieved1, "FileID"));
+
+            var retrieved2 = files.Where(x => x.FileName.Equals(file2.FileName)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(file2, retrieved2, "FileID"));
+        }
+
+        [TestMethod]
+        public void UpdateFile_UpdatesTheRightFieldsInTheRightFile()
+        {
+            var file1 =
+                new FileData
+                {
+                    FileName = "pain_elemental.txt",
+                    FileTypeID = FileType.SaveGame,
+                    FileOrder = 11,
+                    Description = "brown caco",
+                    DateCreated = DateTime.Parse("11/7/2004"),
+                    GameFileID = 222,
+                    SourcePortID = 2,
+                    OriginalFileName = "paine.txt",
+                    OriginalFilePath = "monsters\\paine.txt",
+                    UserTitle = "What if a demon shot more demons out of its mouth",
+                    UserDescription = "What if a pain elemental shot more pain elementals out of its mouth",
+                    Map = "s34"
+                };
+
+            var wrongFile =
+                new FileData
+                {
+                    FileName = "hellknight.txt",
+                    FileTypeID = FileType.Screenshot,
+                    FileOrder = 2,
+                    Description = "the cheapest monster",
+                    DateCreated = DateTime.Parse("1/3/2007"),
+                    GameFileID = 222,
+                    SourcePortID = 5,
+                    OriginalFileName = "hk.txt",
+                    OriginalFilePath = "monsters\\hk.txt",
+                    UserTitle = "Change the color, ship it",
+                    UserDescription = "Deadlines are deadlines",
+                    Map = "ooo"
+                };
+
+            database.InsertFile(file1);
+            database.InsertFile(wrongFile);
+
+            // Need to fetch so that the primary key is populated.
+            var savedFiles = database.GetFiles(new GameFile { GameFileID = 222 });
+            var savedFile1 = savedFiles.Where(x => x.FileName.Equals(file1.FileName)).First();
+
+            // Update every updatable field with new value
+            savedFile1.SourcePortID = 33;
+            savedFile1.Description = "New Description";
+            savedFile1.FileOrder = 44;
+            savedFile1.DateCreated = new DateTime(2011, 3, 2);
+            savedFile1.UserTitle = "New UserTitle";
+            savedFile1.UserDescription = "New UserDescription";
+            savedFile1.Map = "New map";
+            database.UpdateFile(savedFile1);
+
+            var updatedFiles = database.GetFiles(new GameFile { GameFileID = 222 });
+
+            // Values were updated in that record
+            var retrieved1 = updatedFiles.Where(x => x.FileID.Equals(savedFile1.FileID)).First();
+            Assert.AreEqual(file1.FileName, retrieved1.FileName);
+            Assert.AreEqual(33, retrieved1.SourcePortID);
+            Assert.AreEqual("New Description", retrieved1.Description);
+            Assert.AreEqual(44, retrieved1.FileOrder);
+            Assert.AreEqual(new DateTime(2011, 3, 2), retrieved1.DateCreated);
+            Assert.AreEqual("New UserTitle", retrieved1.UserTitle);
+            Assert.AreEqual("New UserDescription", retrieved1.UserDescription);
+            Assert.AreEqual("New map", retrieved1.Map);
+
+            // The other record was unaffected
+            var retrieved2 = updatedFiles.Where(x => x.FileName.Equals(wrongFile.FileName)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(wrongFile, retrieved2, "FileID"));
+        }
+
+        [TestMethod]
+        public void DeleteFile_FileID_DeletesJustThatFile()
+        {
+            var file1 =
+                new FileData
+                {
+                    FileName = "chaingunner.txt",
+                    FileTypeID = FileType.Demo,
+                    FileOrder = 5,
+                    Description = "Bastard hitscanner",
+                    DateCreated = DateTime.Parse("7/11/2006"),
+                    GameFileID = 123,
+                    SourcePortID = 9,
+                    OriginalFileName = "chaingun_dude.txt",
+                    OriginalFilePath = "monsters\\chaingun_dude.txt",
+                    UserTitle = "I hate this guy",
+                    UserDescription = "Kill them kill them",
+                    Map = "E1M2"
+                };
+
+            var wrongFile =
+                new FileData
+                {
+                    FileName = "wrongo.txt",
+                    FileTypeID = FileType.TileImage,
+                    FileOrder = 99,
+                    Description = "Something else",
+                    DateCreated = DateTime.Parse("11/7/1921"),
+                    GameFileID = 123,
+                    SourcePortID = 88,
+                    OriginalFileName = "nope.txt",
+                    OriginalFilePath = "bad\\nope.txt",
+                    UserTitle = "Yeah nah",
+                    UserDescription = "Womp womp womp",
+                    Map = "555"
+                };
+
+            database.InsertFile(file1);
+            database.InsertFile(wrongFile);
+
+            // Need to fetch so that the primary key is populated.
+            var savedFiles = database.GetFiles();
+            var savedFile1 = savedFiles.Where(x => x.FileName.Equals(file1.FileName)).First();
+
+            database.DeleteFile(savedFile1);
+
+            var files = database.GetFiles();
+
+            Assert.AreEqual(1, files.Count());
+            Assert.AreEqual(wrongFile.FileName, files.First().FileName);
+        }
+
+        [TestMethod]
+        public void DeleteFile_GameFileID_DeletesMatchingFiles()
+        {
+            var file1 =
+                new FileData
+                {
+                    FileName = "pinky_demon.txt",
+                    FileTypeID = FileType.Thumbnail,
+                    FileOrder = 8,
+                    Description = "oink",
+                    DateCreated = DateTime.Parse("17/06/2008"),
+                    GameFileID = 777,
+                    SourcePortID = 9,
+                    OriginalFileName = "pinky.txt",
+                    OriginalFilePath = "monsters\\pinky.txt",
+                    UserTitle = "Should be called piggy demon am I right",
+                    UserDescription = "Use a rocket for the dumbest suicide imaginable",
+                    Map = "E1M3"
+                };
+
+            var file2 =
+                new FileData
+                {
+                    FileName = "revenant.txt",
+                    FileTypeID = FileType.SaveGame,
+                    FileOrder = 10,
+                    Description = "evil bastard",
+                    DateCreated = DateTime.Parse("1/1/2014"),
+                    GameFileID = 777,
+                    SourcePortID = 8,
+                    OriginalFileName = "rev.txt",
+                    OriginalFilePath = "monsters\\rev.txt",
+                    UserTitle = "Awful horrible demon",
+                    UserDescription = "Kill it before it kills you",
+                    Map = "E2M4"
+                };
+
+            var wrongFile =
+                new FileData
+                {
+                    FileName = "wrongy.txt",
+                    FileTypeID = FileType.Demo,
+                    FileOrder = 99,
+                    Description = "Naaaah",
+                    DateCreated = DateTime.Parse("7/2/1933"),
+                    GameFileID = 11,
+                    SourcePortID = 60,
+                    OriginalFileName = "bah.txt",
+                    OriginalFilePath = "bad\\bah.txt",
+                    UserTitle = "bah humbug",
+                    UserDescription = "Don't pick me",
+                    Map = "MAP04"
+                };
+
+            database.InsertFile(file1);
+            database.InsertFile(file2);
+            database.InsertFile(wrongFile);
+
+            database.DeleteFile(new GameFile { GameFileID = 777 });
+
+            var files = database.GetFiles();
+
+            Assert.AreEqual(1, files.Count());
+            Assert.AreEqual(wrongFile.FileName, files.First().FileName);
+        }
+
+        //[TestMethod]
+        /*
         public void TestDeleteFile()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var gameFileIDs = CreateTestFiles().Select(x => x.GameFileID).Distinct();
+            var gameFileIDs = insertedFiles.Select(x => x.GameFileID).Distinct();
 
             int id = gameFileIDs.First();
 
-            var dbFiles = adapter.GetFiles(new GameFile() { GameFileID = id });
+            var dbFiles = database.GetFiles(new GameFile() { GameFileID = id });
             int count = dbFiles.Count();
             foreach (var dbFile in dbFiles)
             {
-                adapter.DeleteFile(dbFile);
+                database.DeleteFile(dbFile);
                 count--;
-                Assert.AreEqual(count, adapter.GetFiles(new GameFile() { GameFileID = id }).Count());
+                Assert.AreEqual(count, database.GetFiles(new GameFile() { GameFileID = id }).Count());
             }
 
-
             id = gameFileIDs.Skip(1).First();
-            adapter.DeleteFile(new GameFile() { GameFileID = id });
-            Assert.AreEqual(0, adapter.GetFiles(new GameFile() { GameFileID = id }).Count());
-        }
+            database.DeleteFile(new GameFile() { GameFileID = id });
+            Assert.AreEqual(0, database.GetFiles(new GameFile() { GameFileID = id }).Count());
+        }*/
     }
 }

--- a/UnitTest/Tests/TestFile.cs
+++ b/UnitTest/Tests/TestFile.cs
@@ -421,7 +421,7 @@ namespace UnitTest.Tests
                     FileTypeID = FileType.Thumbnail,
                     FileOrder = 8,
                     Description = "oink",
-                    DateCreated = DateTime.Parse("17/06/2008"),
+                    DateCreated = DateTime.Parse("04/06/2008"),
                     GameFileID = 777,
                     SourcePortID = 9,
                     OriginalFileName = "pinky.txt",
@@ -476,27 +476,5 @@ namespace UnitTest.Tests
             Assert.AreEqual(1, files.Count());
             Assert.AreEqual(wrongFile.FileName, files.First().FileName);
         }
-
-        //[TestMethod]
-        /*
-        public void TestDeleteFile()
-        {
-            var gameFileIDs = insertedFiles.Select(x => x.GameFileID).Distinct();
-
-            int id = gameFileIDs.First();
-
-            var dbFiles = database.GetFiles(new GameFile() { GameFileID = id });
-            int count = dbFiles.Count();
-            foreach (var dbFile in dbFiles)
-            {
-                database.DeleteFile(dbFile);
-                count--;
-                Assert.AreEqual(count, database.GetFiles(new GameFile() { GameFileID = id }).Count());
-            }
-
-            id = gameFileIDs.Skip(1).First();
-            database.DeleteFile(new GameFile() { GameFileID = id });
-            Assert.AreEqual(0, database.GetFiles(new GameFile() { GameFileID = id }).Count());
-        }*/
     }
 }

--- a/UnitTest/Tests/TestGameFile.cs
+++ b/UnitTest/Tests/TestGameFile.cs
@@ -14,6 +14,8 @@ namespace UnitTest.Tests
     {
         private static string s_garbage = "'s like = % ";
 
+        private IDataSourceAdapter database;
+
         private static readonly GameFileFieldType[] s_fields = new GameFileFieldType[]
         {
             GameFileFieldType.GameFileID,
@@ -92,24 +94,6 @@ namespace UnitTest.Tests
             return files;
         }
 
-        private List<IIWadData> CreateTestIWadList()
-        {
-            List<IIWadData> wads = new List<IIWadData>();
-            int count = 0;
-
-            for (int i = 0; i < 5; i++)
-            {
-                wads.Add(new IWadData()
-                {
-                    IWadID = ++count,
-                    FileName = Guid.NewGuid().ToString(),
-                    Name = Guid.NewGuid().ToString()
-                });
-            }
-
-            return wads;
-        }
-
         private List<ITagData> CreateTestTagList()
         {
             List<ITagData> tags = new List<ITagData>();
@@ -137,17 +121,29 @@ namespace UnitTest.Tests
             return map;
         }
 
+        [TestInitialize]
+        public void Initialize()
+        {
+            database = TestUtil.CreateAdapter();
+            TestInsertGameFile();
+            TestInsertTag();
+            TestInsertTagMap();
+        }
+
+        [TestCleanup]
+        public void CleanDatabase()
+        {
+            var dataAccess = ((DbDataSourceAdapter)database).DataAccess;
+            dataAccess.ExecuteNonQuery("delete from GameFiles");
+            dataAccess.ExecuteNonQuery("delete from Tags");
+            dataAccess.ExecuteNonQuery("delete from TagMapping");
+        }
+
+
         [TestMethod]
         public void TestGameFileData()
         {
-            TestInsertGameFile();
-            TestInsertIWad();
-
-            TestInsertTag();
-            TestInsertTagMap();
-
             TestGameFileSelect();
-            TestIWadSelect();
             TestTagSelect();
             TestTagMapSelect();
             TestGameFileTagging();
@@ -164,9 +160,6 @@ namespace UnitTest.Tests
             TestUpdateFileName();
             TestUpdateFields();
             TestUpdateGameFiles();
-            TestUpdateIWads();
-            TestGetGameFileIWads();
-            TestDeleteIWad();
             TestUpdateWhere();
             TestDelete();
         }
@@ -177,14 +170,6 @@ namespace UnitTest.Tests
             var gameFiles = CreateTestFileList();
             foreach (var gameFile in gameFiles)
                 adapter.InsertGameFile(gameFile);
-        }
-
-        public void TestInsertIWad()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var iwads = CreateTestIWadList();
-            foreach (var iwad in iwads)
-                adapter.InsertIWad(iwad);
         }
 
         public void TestInsertTag()
@@ -203,6 +188,7 @@ namespace UnitTest.Tests
                 adapter.InsertTagMapping(map);
         }
 
+        // Check the number of game files retrieved is the same as saved
         public void TestGameFileSelect()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -213,13 +199,7 @@ namespace UnitTest.Tests
             Assert.IsTrue(adapter.GetGameFileNames().Count() == gameFiles.Count);
         }
 
-        public void TestIWadSelect()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var iwads = CreateTestIWadList();
-            Assert.IsTrue(adapter.GetIWads().Count() == iwads.Count);
-        }
-
+        // Check the number of Tags retrieved is the same as saved
         public void TestTagSelect()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -227,6 +207,7 @@ namespace UnitTest.Tests
             Assert.IsTrue(adapter.GetTags().Count() == tags.Count);
         }
 
+        // Check the number of TagMappings retrieved is the same as saved, and the same as the number of gamefiles
         public void TestTagMapSelect()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -235,6 +216,7 @@ namespace UnitTest.Tests
             Assert.IsTrue(adapter.GetGameFiles().Count() == tagMap.Count);
         }
 
+        // Check that the number of tags mappings committed for a GameFile is the same as the number saved
         public void TestGameFileTagging()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -248,6 +230,7 @@ namespace UnitTest.Tests
             }
         }
 
+        // ??? Check searching behaviour with various options
         public void TestGameFileTaggingSearch()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -268,6 +251,7 @@ namespace UnitTest.Tests
             }
         }
 
+        // ??? Check searching behaviour with various options
         public void TestSelectFields()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -300,6 +284,7 @@ namespace UnitTest.Tests
             }
         }
 
+        // ??? Check searching behaviour with various options
         public void TestGetFileNameByFileName()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -314,6 +299,7 @@ namespace UnitTest.Tests
             }
         }
 
+        // ??? Check searching behaviour with various options
         public void TestGetFileNameByID()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -330,6 +316,7 @@ namespace UnitTest.Tests
             }
         }
 
+        // ??? Check searching behaviour with various options
         public void TestFullLikeFileName()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -345,6 +332,7 @@ namespace UnitTest.Tests
             }
         }
 
+        // ??? Check searching behaviour with various options
         public void TestPartialLikeFileName()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -354,6 +342,7 @@ namespace UnitTest.Tests
             Assert.AreEqual(gameFilesFind.Count(), CreateTestFileList().Count);
         }
 
+        // ??? Check searching behaviour with various options
         public void TestPartialLikeFileName_SqlSyntax()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -363,6 +352,7 @@ namespace UnitTest.Tests
             Assert.AreEqual(3, gameFilesFind.Count());
         }
 
+        // ??? Check searching behaviour with various options
         public void TestPartialLikeTitle()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -372,6 +362,7 @@ namespace UnitTest.Tests
             Assert.AreEqual(gameFilesFind.Count(), CreateTestFileList().Count);
         }
 
+        // ??? Check searching behaviour with various options
         public void TestPartialLikeDescription()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -381,6 +372,7 @@ namespace UnitTest.Tests
             Assert.AreEqual(gameFilesFind.Count(), CreateTestFileList().Count);
         }
 
+        // ??? Check searching behaviour with various options
         public void TestPartialLikeAuthor()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -390,6 +382,7 @@ namespace UnitTest.Tests
             Assert.AreEqual(gameFilesFind.Count(), CreateTestFileList().Count);
         }
 
+        // ??? Check searching behaviour with various options
         public void TestUpdateFileName()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -410,6 +403,7 @@ namespace UnitTest.Tests
             }
         }
 
+        // ??? 
         public void TestUpdateFields()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -433,6 +427,7 @@ namespace UnitTest.Tests
             }
         }
 
+
         public void TestUpdateGameFiles()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
@@ -445,49 +440,6 @@ namespace UnitTest.Tests
                 IGameFile gameFileFind = adapter.GetGameFile(gameFile.FileName);
                 Assert.IsTrue(gameFileFind != null);
                 Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFileFind));
-            }
-        }
-
-        public void TestUpdateIWads()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var iwads = adapter.GetIWads().ToList();
-            var gameFiles = CreateTestFileList();
-
-            var gameFileIwads = gameFiles.Take(iwads.Count).ToList();
-            for (int i = 0; i < gameFileIwads.Count; i++)
-            {
-                iwads[i].GameFileID = gameFileIwads[i].IWadID;
-                adapter.UpdateIWad(iwads[i]);
-            }
-
-            iwads = adapter.GetIWads().ToList();
-
-            foreach (var gameFile in gameFileIwads)
-            {
-                Assert.IsTrue(iwads.Count(x => x.GameFileID == gameFile.GameFileID) == 1);
-            }
-        }
-
-        public void TestGetGameFileIWads()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var gameFileIwads = CreateTestIWadList();
-
-            Assert.IsTrue(adapter.GetGameFileIWads().Count() == gameFileIwads.Count);
-        }
-
-        public void TestDeleteIWad()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var iwads = adapter.GetIWads();
-            int count = iwads.Count();
-
-            foreach (var iwad in iwads)
-            {
-                adapter.DeleteIWad(iwad);
-                count--;
-                Assert.AreEqual(count, adapter.GetIWads().Count());
             }
         }
 

--- a/UnitTest/Tests/TestGameFile.cs
+++ b/UnitTest/Tests/TestGameFile.cs
@@ -2,144 +2,51 @@
 using DoomLauncher.DataSources;
 using DoomLauncher.Interfaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace UnitTest.Tests
 {
     [TestClass]
     public class TestGameFile
     {
-        private static string s_garbage = "'s like = % ";
-
         private IDataSourceAdapter database;
 
-        private static readonly GameFileFieldType[] s_fields = new GameFileFieldType[]
-        {
-            GameFileFieldType.GameFileID,
-            GameFileFieldType.Filename,
-            GameFileFieldType.Author,
-            GameFileFieldType.Title,
-            GameFileFieldType.Description,
-            GameFileFieldType.Downloaded,
-            GameFileFieldType.LastPlayed,
-            GameFileFieldType.ReleaseDate,
-            GameFileFieldType.Comments,
-            GameFileFieldType.Rating,
-            GameFileFieldType.MapCount,
-            GameFileFieldType.MinutesPlayed,
-            GameFileFieldType.IWadID
-        };
-
-        private GameFile CreateGameFile(string filename, int count)
+        private GameFile CreateGameFile(string filename, int salt)
         {
             DateTime dt = DateTime.Parse("1/1/17");
 
             GameFile gameFile = new GameFile
             {
                 FileName = filename,
-                Author = string.Format("Author_{0}", filename),
-                Description = string.Format("Description_{0}", filename),
-                Title = string.Format("Title_{0}", filename),
-                Comments = string.Format("Comments_{0}", filename),
+                Author = "the author" + salt,
+                Description = "the description" + salt,
+                Title = "the title" + salt,
+                Comments = "the comments" + salt,
                 ReleaseDate = dt,
                 Downloaded = dt,
                 LastPlayed = dt,
-                IWadID = count,
-                Rating = count,
-                MinutesPlayed = count,
-                MapCount = count,
-                SourcePortID = count,
-                SettingsExtraParams = filename,
-                SettingsFiles = filename,
-                SettingsFilesIWAD = filename,
-                SettingsFilesSourcePort = filename,
-                SettingsMap = filename,
-                SettingsSkill = filename,
-                SettingsSpecificFiles = filename,
-                SettingsGameProfileID = count
+                IWadID = 22 + salt,
+                Rating = 33 + salt,
+                MinutesPlayed = 44 + salt,
+                MapCount = 55 + salt,
+                SourcePortID = 66 + salt,
+                SettingsExtraParams = "the extra params" + salt,
+                SettingsFiles = "the settings files" + salt,
+                SettingsFilesIWAD = "the settings files iwad" + salt,
+                SettingsFilesSourcePort = "the settings files source port" + salt,
+                SettingsMap = "the settings map" + salt,
+                SettingsSkill = "the settings skill" + salt,
+                SettingsSpecificFiles = "the settings specific files" + salt,
+                SettingsGameProfileID = 567 + salt
             };
 
             return gameFile;
-        }
-
-        private List<IGameFile> CreateTestFileList()
-        {
-            List<IGameFile> files = new List<IGameFile>();
-            int count = 0;
-
-            for (int i = 0; i < 3; i++)
-            {
-                GameFile gameFile = CreateGameFile(string.Format("Test{0}.Zip", ++count), count);
-                gameFile.GameFileID = count;
-                files.Add(gameFile);
-            }
-
-            for (int i = 0; i < 3; i++)
-            {
-                GameFile gameFile = CreateGameFile(string.Format("TEST{0}.Zip", ++count), count);
-                gameFile.GameFileID = count;
-                files.Add(gameFile);
-            }
-
-            for (int i = 0; i < 3; i++)
-            {
-                GameFile gameFile = CreateGameFile(string.Format("TEST{0}{1}.Zip", s_garbage, ++count), count);
-                gameFile.GameFileID = count;
-                files.Add(gameFile);
-            }
-
-            return files;
-        }
-
-        private List<ITagData> CreateTestTagList()
-        {
-            List<ITagData> tags = new List<ITagData>();
-            int count = 0;
-
-            for (int i = 0; i < 6; i++)
-                tags.Add(new TagData() { TagID = ++count, Name = Guid.NewGuid().ToString() });
-
-            return tags;
-        }
-
-        private List<ITagMapping> CreateTestTagMapping()
-        {
-            List<ITagMapping> map = new List<ITagMapping>();
-            var gameFiles = CreateTestFileList();
-            var tags = CreateTestTagList();
-            int count = 0;
-
-            foreach(var gameFile in gameFiles)
-            {
-                map.Add(new TagMapping() { FileID = gameFile.GameFileID.Value, TagID = tags[count % tags.Count].TagID });
-                count++;
-            }
-
-            return map;
-        }
-
-        public void TestInsertGameFile()
-        {
-            var gameFiles = CreateTestFileList();
-            foreach (var gameFile in gameFiles)
-                database.InsertGameFile(gameFile);
-        }
-
-        public void TestInsertTag()
-        {
-            var tags = CreateTestTagList();
-            foreach (var tag in tags)
-                database.InsertTag(tag);
-        }
-
-        public void TestInsertTagMap()
-        {
-            var mapTags = CreateTestTagMapping();
-            foreach (var map in mapTags)
-                database.InsertTagMapping(map);
         }
 
 
@@ -147,9 +54,6 @@ namespace UnitTest.Tests
         public void Initialize()
         {
             database = TestUtil.CreateAdapter();
-            TestInsertGameFile();
-            TestInsertTag();
-            TestInsertTagMap();
         }
 
         [TestCleanup]
@@ -157,326 +61,369 @@ namespace UnitTest.Tests
         {
             var dataAccess = ((DbDataSourceAdapter)database).DataAccess;
             dataAccess.ExecuteNonQuery("delete from GameFiles");
-            dataAccess.ExecuteNonQuery("delete from Tags");
-            dataAccess.ExecuteNonQuery("delete from TagMapping");
         }
 
         [TestMethod]
-        public void GetGameFiles_ReturnsTheExpectedGameFilesCount()
+        public void GetGameFiles_ReturnsAllGameFiles ()
         {
-            var gameFiles = CreateTestFileList();
-
-            Assert.IsTrue(database.GetGameFiles().Count() == gameFiles.Count);
-            Assert.IsTrue(database.GetGameFilesCount() == gameFiles.Count);
-            Assert.IsTrue(database.GetGameFileNames().Count() == gameFiles.Count);
-        }
-
-        [TestMethod]
-        public void GetTags_ReturnsTheExpectedTagCount()
-        {
-            var tags = CreateTestTagList();
-            Assert.IsTrue(database.GetTags().Count() == tags.Count);
-        }
-
-        [TestMethod]
-        public void GetTagMappings_MatchesTheGameFileCount()
-        {
-            var tagMap = CreateTestTagMapping();
-            Assert.IsTrue(database.GetTagMappings().Count() == tagMap.Count);
-            Assert.IsTrue(database.GetGameFiles().Count() == tagMap.Count);
-        }
-
-        [TestMethod]
-        public void GetGameFiles_Tag_ReturnsTheExpectedGameFilesCount()
-        {
-            var tags = database.GetTags();
-            var tagMap = database.GetTagMappings();
-
-            foreach (var tag in tags)
+            var gameFile1 = new GameFile
             {
-                var gameFileGet = database.GetGameFiles(tag);
-                Assert.IsTrue(gameFileGet.Count() == tagMap.Count(x => x.TagID == tag.TagID));
-            }
-        }
+                FileName = "cacodemon.png",
+                Author = "John Romero",
+                Description = "Red ball of fury",
+                Title = "Cacodemon image",
+                Comments = "Hi res",
+                ReleaseDate = DateTime.Parse("2/1/2018"),
+                Downloaded = DateTime.Parse("3/5/2024"),
+                LastPlayed = DateTime.Parse("4/5/2024"),
+                IWadID = 9,
+                Rating = 4,
+                MinutesPlayed = 55,
+                MapCount = 4,
+                SourcePortID = 3,
+                SettingsExtraParams = "extra",
+                SettingsFiles = "settings file",
+                SettingsFilesIWAD = "settings file iwad",
+                SettingsFilesSourcePort = "settings file sp",
+                SettingsMap = "settings map",
+                SettingsSkill = "settings skill",
+                SettingsSpecificFiles = "ssf",
+                SettingsGameProfileID = 44
+            };
+            database.InsertGameFile(gameFile1);
 
-        [TestMethod]
-        public void GetGameFiles_Options_Tag_ReturnsTheExpectedGameFileCount()
-        {
-            var tags = database.GetTags();
-            var tagMap = database.GetTagMappings();
-
-            foreach (var tag in tags)
+            var gameFile2 = new GameFile
             {
-                var gameFileGet = database.GetGameFiles(new GameFileGetOptions(s_fields), tag);
-                Assert.IsTrue(gameFileGet.Count() == tagMap.Count(x => x.TagID == tag.TagID));
-            }
+                FileName = "baron.png",
+                Author = "Bobby Prince",
+                Description = "tough but fair",
+                Title = "Baron of Hell",
+                Comments = "Made from clay models",
+                ReleaseDate = null,
+                Downloaded = null,
+                LastPlayed = null,
+                IWadID = null,
+                Rating = null,
+                MinutesPlayed = 4,
+                MapCount = null,
+                SourcePortID = null,
+                SettingsExtraParams = "aaa",
+                SettingsFiles = "bbb",
+                SettingsFilesIWAD = "ccc",
+                SettingsFilesSourcePort = "ddd",
+                SettingsMap = "eee",
+                SettingsSkill = "fff",
+                SettingsSpecificFiles = "ggg",
+                SettingsGameProfileID = null
+            };
+            database.InsertGameFile(gameFile2);
 
-            foreach (var tag in tags)
+            var gameFiles = database.GetGameFiles();
+
+            Assert.AreEqual(gameFiles.Count(), 2);
+            Assert.AreEqual(database.GetGameFiles().Count(), 2);
+            Assert.AreEqual(database.GetGameFilesCount(), 2);
+            Assert.AreEqual(database.GetGameFileNames().Count(), 2);
+
+            var retrieved1 = gameFiles.Where(x => x.FileName.Equals(gameFile1.FileName)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(gameFile1, retrieved1, "GameFileID"));
+
+            var retrieved2 = gameFiles.Where(x => x.FileName.Equals(gameFile2.FileName)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(gameFile2, retrieved2, "GameFileID"));
+        }
+
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsTheSpecifiedFields()
+        {
+            var gameFile1 = CreateGameFile("keen.zip", 0);
+            gameFile1.Map = "Dangerous Dave";
+            database.InsertGameFile(gameFile1);
+
+            var fields = new GameFileFieldType[] 
+            { 
+                GameFileFieldType.Filename, 
+                GameFileFieldType.Map 
+            };
+
+            var options = new GameFileGetOptions(fields);
+
+            var gameFiles = database.GetGameFiles(options);
+            Assert.AreEqual(1, gameFiles.Count());
+
+            var retrievedGameFile1 = gameFiles.First();
+            Assert.AreEqual("", retrievedGameFile1.Description);
+            Assert.IsNull(retrievedGameFile1.Rating);
+            Assert.AreEqual(gameFile1.FileName, retrievedGameFile1.FileName);
+            Assert.AreEqual(gameFile1.Map, retrievedGameFile1.Map);
+        }
+
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsMatching()
+        {
+            var gameFile1 = CreateGameFile("dukenukem.zip", 1);
+            gameFile1.Rating = 5;
+            gameFile1.Comments = "righto!!!";
+            database.InsertGameFile(gameFile1);
+
+            var wrongGameFile = CreateGameFile("jazzjackrabbit.zip", 2);
+            database.InsertGameFile(wrongGameFile);
+
+            var options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Filename, "dukenukem.zip"));
+
+            var retrievedGameFiles = database.GetGameFiles(options);
+
+            Assert.AreEqual(1, retrievedGameFiles.Count());
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(gameFile1, retrievedGameFiles.First(), "GameFileID"));
+        }
+
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsLike()
+        {
+            var gameFile1 = CreateGameFile("banana.zip", 3);
+            database.InsertGameFile(gameFile1);
+
+            var gameFile2 = CreateGameFile("banano.zip", 4);
+            database.InsertGameFile(gameFile2);
+
+            var gameFile3 = CreateGameFile("zanany.zip", 5);
+            database.InsertGameFile(gameFile3);
+
+            var wrongGameFile = CreateGameFile("cucumber.zip", 6);
+            database.InsertGameFile(wrongGameFile);
+
+            var options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Filename, GameFileSearchOp.Like, "%anan%"));
+
+            var retrievedGameFiles = database.GetGameFiles(options);
+
+            Assert.AreEqual(3, retrievedGameFiles.Count());
+
+            var retrievedGameFile1 = retrievedGameFiles.Where(x => x.FileName.Equals(gameFile1.FileName)).FirstOrDefault();
+            Assert.IsNotNull(retrievedGameFile1);
+
+            var retrievedGameFile2 = retrievedGameFiles.Where(x => x.FileName.Equals(gameFile2.FileName)).FirstOrDefault();
+            Assert.IsNotNull(retrievedGameFile2);
+
+            var retrievedGameFile3 = retrievedGameFiles.Where(x => x.FileName.Equals(gameFile3.FileName)).FirstOrDefault();
+            Assert.IsNotNull(retrievedGameFile3);
+        }
+
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsNotMatching()
+        {
+            var gameFile1 = CreateGameFile("batman.zip", 7);
+            gameFile1.Comments = "b";
+            database.InsertGameFile(gameFile1);
+
+            var gameFile2 = CreateGameFile("robin.zip", 8);
+            gameFile2.Comments = "r";
+            database.InsertGameFile(gameFile2);
+
+            var gameFile3 = CreateGameFile("joker.zip", 9);
+            gameFile3.Comments = "j";
+            database.InsertGameFile(gameFile3);
+
+            var options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Comments, GameFileSearchOp.NotEqual, "r"));
+            var retrievedGameFiles = database.GetGameFiles(options);
+
+            Assert.AreEqual(2, retrievedGameFiles.Count());
+
+            var retrievedGameFile1 = retrievedGameFiles.Where(x => x.FileName.Equals(gameFile1.FileName)).FirstOrDefault();
+            Assert.IsNotNull(retrievedGameFile1);
+
+            var retrievedGameFile3 = retrievedGameFiles.Where(x => x.FileName.Equals(gameFile3.FileName)).FirstOrDefault();
+            Assert.IsNotNull(retrievedGameFile3);
+        }
+
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsLessThan()
+        {
+            var gameFile1 = CreateGameFile("harpo.zip", 10);
+            gameFile1.Rating = 1;
+            database.InsertGameFile(gameFile1);
+
+            var gameFile2 = CreateGameFile("groucho.zip", 11);
+            gameFile2.Rating = 2;
+            database.InsertGameFile(gameFile2);
+
+            var gameFile3 = CreateGameFile("chico.zip", 12);
+            gameFile3.Rating = 3;
+            database.InsertGameFile(gameFile3);
+
+            var options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Rating, GameFileSearchOp.LessThan, "3"));
+            var retrievedGameFiles = database.GetGameFiles(options);
+
+            Assert.AreEqual(2, retrievedGameFiles.Count());
+
+            var retrievedGameFile1 = retrievedGameFiles.Where(x => x.FileName.Equals(gameFile1.FileName)).FirstOrDefault();
+            Assert.IsNotNull(retrievedGameFile1);
+
+            var retrievedGameFile2 = retrievedGameFiles.Where(x => x.FileName.Equals(gameFile2.FileName)).FirstOrDefault();
+            Assert.IsNotNull(retrievedGameFile2);
+        }
+
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsGreaterThan()
+        {
+            var gameFile1 = CreateGameFile("green.zip", 13);
+            gameFile1.MapCount = 5;
+            database.InsertGameFile(gameFile1);
+
+            var gameFile2 = CreateGameFile("blue.zip", 14);
+            gameFile2.MapCount = 6;
+            database.InsertGameFile(gameFile2);
+
+            var gameFile3 = CreateGameFile("red.zip", 15);
+            gameFile3.MapCount = null;
+            database.InsertGameFile(gameFile3);
+
+            var options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.MapCount, GameFileSearchOp.GreaterThan, "5"));
+            var retrievedGameFiles = database.GetGameFiles(options);
+
+            Assert.AreEqual(1, retrievedGameFiles.Count());
+
+            var retrievedGameFile2 = retrievedGameFiles.Where(x => x.FileName.Equals(gameFile2.FileName)).FirstOrDefault();
+            Assert.AreEqual(gameFile2.FileName, "blue.zip");
+        }
+
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsMatchingWithSelectedFields()
+        {
+            var gameFile1 = CreateGameFile("doomslayer.zip", 16);
+            gameFile1.Map = "E1M1";
+            gameFile1.Author = "Adrian Carmack";
+            database.InsertGameFile(gameFile1);
+
+            var wrongGameFile = CreateGameFile("animalcrossing.zip", 16);
+            database.InsertGameFile(wrongGameFile);
+
+            var fields = new GameFileFieldType[]
             {
-                var options = new GameFileGetOptions(s_fields, new GameFileSearchField(GameFileFieldType.GameFileID, "1"));
-                var gameFileGet = database.GetGameFiles(options, tag);
-                Assert.IsTrue(gameFileGet.Count() == tagMap.Count(x => x.TagID == tag.TagID && x.FileID == 1));
-            }
+                GameFileFieldType.Map,
+                GameFileFieldType.Author
+            };
+
+            var options = new GameFileGetOptions(fields, new GameFileSearchField(GameFileFieldType.Filename, "doomslayer.zip"));
+
+            var retrievedGameFiles = database.GetGameFiles(options);
+
+            Assert.AreEqual(1, retrievedGameFiles.Count());
+
+            var retrievedGameFile1 = retrievedGameFiles.First();
+            Assert.AreEqual(gameFile1.Map, retrievedGameFile1.Map);
+            Assert.AreEqual(gameFile1.Author, retrievedGameFile1.Author);
         }
 
         [TestMethod]
-        public void GetGameFiles_Options_ReturnsExpectedGameFiles()
+        public void GetGameFile_ReturnsGameFileWithMatchingFilename()
         {
-            var gameFiles = CreateTestFileList();
+            var gameFile1 = CreateGameFile("blah.zip", 17);
+            database.InsertGameFile(gameFile1);
 
-            var selectGameFiles = database.GetGameFiles(new GameFileGetOptions(s_fields));
+            var wrongGameFile = CreateGameFile("wrongwrongwrong.zip", 18);
+            database.InsertGameFile(wrongGameFile);
 
-            foreach(var gameFile in gameFiles)
-            {
-                var selectGameFile = selectGameFiles.FirstOrDefault(x => x.GameFileID == gameFile.GameFileID);
-                Assert.IsNotNull(selectGameFile);
-                Assert.IsTrue(selectGameFile.SettingsExtraParams.Length == 0);
-                Assert.IsTrue(selectGameFile.SettingsFiles.Length == 0);
-                Assert.IsTrue(selectGameFile.SettingsMap.Length == 0);
-                Assert.IsTrue(selectGameFile.SettingsSkill.Length == 0);
-                Assert.IsTrue(selectGameFile.SettingsSpecificFiles.Length == 0);
-
-                Assert.IsTrue(selectGameFile.FileName.Equals(gameFile.FileName));
-                Assert.IsTrue(selectGameFile.Author.Equals(gameFile.Author));
-                Assert.IsTrue(selectGameFile.Title.Equals(gameFile.Title));
-                Assert.IsTrue(selectGameFile.Description.Equals(gameFile.Description));
-                Assert.IsTrue(selectGameFile.Downloaded.Equals(gameFile.Downloaded));
-                Assert.IsTrue(selectGameFile.LastPlayed.Equals(gameFile.LastPlayed));
-                Assert.IsTrue(selectGameFile.ReleaseDate.Equals(gameFile.ReleaseDate));
-                Assert.IsTrue(selectGameFile.Comments.Equals(gameFile.Comments));
-                Assert.IsTrue(selectGameFile.Rating.Equals(gameFile.Rating));
-                Assert.IsTrue(selectGameFile.MapCount.Equals(gameFile.MapCount));
-                Assert.IsTrue(selectGameFile.MinutesPlayed.Equals(gameFile.MinutesPlayed));
-                Assert.IsTrue(selectGameFile.IWadID.Equals(gameFile.IWadID));
-            }
+            var retrievedGameFile = database.GetGameFile("blah.zip");
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(gameFile1, retrievedGameFile, "GameFileID"));
         }
 
         [TestMethod]
-        public void GetFileName_String_ReturnsGameFileOfThatName()
+        public void UpdateGameFile_UpdatesFields()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var gameFiles = CreateTestFileList();
+            var gameFile1 = CreateGameFile("explosion.zip", 20);
+            database.InsertGameFile(gameFile1);
 
-            foreach (var gameFile in gameFiles)
-            {
-                var gameFileFind = adapter.GetGameFile(gameFile.FileName.ToLower()); //check that search is not case sensitive
+            var wrongGameFile = CreateGameFile("notme.zip", 21);
+            database.InsertGameFile(wrongGameFile);
 
-                Assert.AreEqual(gameFile, gameFileFind); //Default operator, only checks against FileName
-                Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFileFind));
-            }
+            var savedGameFile1 = database.GetGameFile("explosion.zip");
+            savedGameFile1.Comments = "Hi";
+            savedGameFile1.Description = "Good stuff";
+            savedGameFile1.MinutesPlayed = 444;
+
+            database.UpdateGameFile(savedGameFile1);
+
+            var retrievedGameFile1 = database.GetGameFile("explosion.zip");
+            Assert.IsTrue(TestUtil.AllFieldsEqual(savedGameFile1, retrievedGameFile1));
+
+            var retrievedWrongGameFile = database.GetGameFile("notme.zip");
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(wrongGameFile, retrievedWrongGameFile, "GameFileID"));
         }
 
         [TestMethod]
-        public void GetGameFiles_Options_ReturnsGameFileById()
+        public void UpdateGameFile_UpdatesOnlySpecifiedFields()
         {
-            var gameFiles = CreateTestFileList();
+            var gameFile1 = CreateGameFile("rabbit.zip", 22);
+            gameFile1.Comments = "Don't update this";
+            gameFile1.Description = "Update me";
+            database.InsertGameFile(gameFile1);
 
-            foreach (var gameFile in gameFiles)
-            {
-                IGameFileGetOptions options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.GameFileID, gameFile.GameFileID.ToString()));
-                var gameFilesFind = database.GetGameFiles(options);
+            var wrongGameFile = CreateGameFile("incorrect.zip", 23);
+            database.InsertGameFile(wrongGameFile);
 
-                Assert.AreEqual(1, gameFilesFind.Count());
-                Assert.AreEqual(gameFile, gameFilesFind.First()); //Default operator, only checks against FileName
-                Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFilesFind.First()));
-            }
+            var savedGameFile1 = database.GetGameFile("rabbit.zip");
+            savedGameFile1.Description = "The new value";
+            savedGameFile1.Comments = "Should be ignored";
+
+            database.UpdateGameFile(savedGameFile1, new GameFileFieldType[] { GameFileFieldType.Description });
+
+            var retrievedGameFile1 = database.GetGameFile("rabbit.zip");
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(gameFile1, retrievedGameFile1, "Description", "GameFileID"));
+            Assert.AreEqual("The new value", retrievedGameFile1.Description);
+
+            var retrievedWrongGameFile = database.GetGameFile("incorrect.zip");
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(wrongGameFile, retrievedWrongGameFile, "GameFileID"));
         }
 
         [TestMethod]
-        public void GetGameFiles_Options_ReturnsGameFileLikeFileName()
+        public void DeleteGameFile_DeletesExistingGameFile()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var gameFiles = CreateTestFileList();
+            var gameFile1 = CreateGameFile("deleteme.zip", 24);
+            database.InsertGameFile(gameFile1);
 
-            foreach (var gameFile in gameFiles)
-            {
-                IGameFileGetOptions options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Filename, GameFileSearchOp.Like, gameFile.FileName));
-                var gameFilesFind = database.GetGameFiles(options);
+            var wrongGameFile = CreateGameFile("keepme.zip", 25);
+            database.InsertGameFile(wrongGameFile);
 
-                Assert.AreEqual(1, gameFilesFind.Count());
-                Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFilesFind.First()));
-            }
-        }
+            var savedGameFile1 = database.GetGameFile("deleteme.zip");
 
-        [TestMethod]
-        public void GetGameFiles_Options_ReturnsGameFilePartialLikeFileName()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            IGameFileGetOptions options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Filename, GameFileSearchOp.Like, "test"));
-            var gameFilesFind = database.GetGameFiles(options);
+            database.DeleteGameFile(savedGameFile1);
 
-            Assert.AreEqual(gameFilesFind.Count(), CreateTestFileList().Count);
-        }
+            var retrievedGameFiles = database.GetGameFiles();
 
-        [TestMethod]
-        public void GetGameFiles_Options_ReturnsGameFilePartialLikeFileName_SqlSyntax()
-        {
-            IGameFileGetOptions options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Filename, GameFileSearchOp.Like, "test" + s_garbage));
-            var gameFilesFind = database.GetGameFiles(options);
-
-            Assert.AreEqual(3, gameFilesFind.Count());
-        }
-
-        [TestMethod]
-        public void GetGameFiles_Options_ReturnsGameFilePartialLikeTitle()
-        {
-            IGameFileGetOptions options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Title, GameFileSearchOp.Like, "test"));
-            var gameFilesFind = database.GetGameFiles(options);
-
-            Assert.AreEqual(gameFilesFind.Count(), CreateTestFileList().Count);
-        }
-
-        [TestMethod]
-        public void GetGameFiles_Options_ReturnsGameFilePartialLikeDescription()
-        {
-            IGameFileGetOptions options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Description, GameFileSearchOp.Like, "test"));
-            var gameFilesFind = database.GetGameFiles(options);
-
-            Assert.AreEqual(gameFilesFind.Count(), CreateTestFileList().Count);
-        }
-
-        [TestMethod]
-        public void GetGameFiles_Options_ReturnsGameFilePartialLikeAuthor()
-        {
-            IGameFileGetOptions options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Author, GameFileSearchOp.Like, "test"));
-            var gameFilesFind = database.GetGameFiles(options);
-
-            Assert.AreEqual(gameFilesFind.Count(), CreateTestFileList().Count);
-        }
-
-        [TestMethod]
-        public void UpdateGameFile_UpdatesFileName()
-        {
-            var gameFiles = CreateTestFileList();
-
-            foreach(var gameFile in gameFiles)
-            {
-                string oldFileName = gameFile.FileName;
-                gameFile.FileName = gameFile.FileName.Replace(gameFile.GameFileID.ToString(), string.Format("Update_{0}", gameFile.GameFileID));
-                database.UpdateGameFile(gameFile, new GameFileFieldType[] { GameFileFieldType.Filename });
-
-                IGameFile gameFileFind = database.GetGameFile(oldFileName);
-                Assert.IsTrue(gameFileFind == null);
-
-                gameFileFind = database.GetGameFile(gameFile.FileName);
-                Assert.AreEqual(gameFile, gameFileFind);
-                Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFileFind));
-            }
-        }
-
-        [TestMethod]
-        public void UpdateGameFile_UpdatesSpecifiedFields()
-        {
-            var gameFiles = CreateTestFileList();
-
-            List<GameFileFieldType> fields = new List<GameFileFieldType>();
-
-            foreach (var enumValue in Enum.GetValues(typeof(GameFileFieldType)))
-                fields.Add((GameFileFieldType)enumValue);
-
-            var names = fields.Select(x => x.ToString());
-            PropertyInfo[] properties = typeof(TestGameFile).GetProperties().Where(x => names.Contains(x.Name)).ToArray();
-            SetRandomFileValues(gameFiles, properties);
-
-            foreach (var gameFile in gameFiles)
-            {
-                database.UpdateGameFile(gameFile, fields.ToArray());
-                IGameFile gameFileFind = database.GetGameFile(gameFile.FileName);
-                Assert.IsTrue(gameFileFind != null);
-                Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFileFind));
-            }
-        }
-
-        [TestMethod]
-        public void UpdateGameFile_UpdatesAllFields()
-        {
-            var gameFiles = CreateTestFileList();
-            SetRandomFileValues(gameFiles, typeof(GameFile).GetProperties());
-
-            foreach(var gameFile in gameFiles)
-            {
-                database.UpdateGameFile(gameFile);
-                IGameFile gameFileFind = database.GetGameFile(gameFile.FileName);
-                Assert.IsTrue(gameFileFind != null);
-                Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFileFind));
-            }
+            Assert.AreEqual(1, retrievedGameFiles.Count());
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(wrongGameFile, retrievedGameFiles.First(), "GameFileID"));
         }
 
         [TestMethod]
         public void UpdateGameFile_UpdatesConditionally()
         {
+            var gameFile1 = CreateGameFile("right1.zip", 26);
+            gameFile1.Author = "Michael Abrash";
+            gameFile1.Comments = "replace me";
+            database.InsertGameFile(gameFile1);
+
+            var gameFile2 = CreateGameFile("right2.zip", 27);
+            gameFile2.Author = "Michael Abrash";
+            gameFile2.Comments = "replace me too";
+            database.InsertGameFile(gameFile2);
+
+            var wrongGameFile = CreateGameFile("wrongo.zip", 28);
+            wrongGameFile.Author = "Scott Miller";
+            wrongGameFile.Comments = "don't replace me";
+            database.InsertGameFile(wrongGameFile);
+
             //Note: This function is only used in SourcePortViewForm.cs
-            var gameFiles = CreateTestFileList();
-            int test = 1000;
+            database.UpdateGameFiles(GameFileFieldType.Author, GameFileFieldType.Comments, "Michael Abrash", "The new comments");
 
-            foreach(var gameFile in gameFiles)
-            {
-                database.UpdateGameFile(gameFile); //Make sure we're in sync with our test list first...
+            var retrievedGameFile1 = database.GetGameFile("right1.zip");
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(gameFile1, retrievedGameFile1, "GameFileID", "Comments"));
+            Assert.AreEqual("The new comments", retrievedGameFile1.Comments);
 
-                //Test setting a real value
-                database.UpdateGameFiles(GameFileFieldType.SourcePortID, GameFileFieldType.SourcePortID, gameFile.SourcePortID, test);
-                gameFile.SourcePortID = test;
+            var retrievedGameFile2 = database.GetGameFile("right2.zip");
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(gameFile2, retrievedGameFile2, "GameFileID", "Comments"));
+            Assert.AreEqual("The new comments", retrievedGameFile2.Comments);
 
-                IGameFile gameFileFind = database.GetGameFile(gameFile.FileName);
-                Assert.IsTrue(gameFileFind != null);
-                Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFileFind));
-
-                //Test setting value to null
-                database.UpdateGameFiles(GameFileFieldType.SourcePortID, GameFileFieldType.SourcePortID, gameFile.SourcePortID, null);
-                gameFile.SourcePortID = null;
-
-                gameFileFind = database.GetGameFile(gameFile.FileName);
-                Assert.IsTrue(gameFileFind != null);
-                Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFileFind));
-
-                test++;
-            }
-        }
-
-        private void SetRandomFileValues(List<IGameFile> gameFiles, PropertyInfo[] properties)
-        {
-            int value = 0;
-            //Properties we do not write to the database
-            string[] exclude = new string[] { "FileSizeBytes", "GameFileID", "FileNameNoPath", "LastDirectory" };
-
-            foreach (var gameFile in gameFiles)
-            {
-                foreach (PropertyInfo pi in properties)
-                {
-                    if (!exclude.Contains(pi.Name))
-                    {
-                        Type pType = pi.PropertyType;
-
-                        if (pType.IsGenericType && pType.GetGenericTypeDefinition() == typeof(Nullable<>))
-                            pType = pType.GetGenericArguments()[0];
-
-                        if (pType == typeof(int))
-                            pi.SetValue(gameFile, ++value);
-                        else if (pType == typeof(double))
-                            pi.SetValue(gameFile, (double)++value);
-                        else if (pType == typeof(string))
-                            pi.SetValue(gameFile, Guid.NewGuid().ToString());
-                        else if (pType == typeof(DateTime))
-                            pi.SetValue(gameFile, DateTime.Now);
-                    }
-                }
-            }
-        }
-
-        [TestMethod]
-        public void DeleteGameFile_DeletesFile()
-        {
-            var gameFiles = CreateTestFileList();
-            int count = gameFiles.Count;
-
-            foreach (var gameFile in gameFiles)
-            {
-                database.DeleteGameFile(gameFile);
-
-                IGameFile gameFileFind = database.GetGameFile(gameFile.FileName);
-                Assert.IsTrue(gameFileFind == null);
-                Assert.AreEqual(database.GetGameFiles().Count(), --count);
-            }
+            var retrievedWrongGameFile = database.GetGameFile("wrongo.zip");
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(wrongGameFile, retrievedWrongGameFile, "GameFileID"));
         }
     }
 }

--- a/UnitTest/Tests/TestGameFile.cs
+++ b/UnitTest/Tests/TestGameFile.cs
@@ -121,6 +121,28 @@ namespace UnitTest.Tests
             return map;
         }
 
+        public void TestInsertGameFile()
+        {
+            var gameFiles = CreateTestFileList();
+            foreach (var gameFile in gameFiles)
+                database.InsertGameFile(gameFile);
+        }
+
+        public void TestInsertTag()
+        {
+            var tags = CreateTestTagList();
+            foreach (var tag in tags)
+                database.InsertTag(tag);
+        }
+
+        public void TestInsertTagMap()
+        {
+            var mapTags = CreateTestTagMapping();
+            foreach (var map in mapTags)
+                database.InsertTagMapping(map);
+        }
+
+
         [TestInitialize]
         public void Initialize()
         {
@@ -139,125 +161,70 @@ namespace UnitTest.Tests
             dataAccess.ExecuteNonQuery("delete from TagMapping");
         }
 
+        [TestMethod]
+        public void GetGameFiles_ReturnsTheExpectedGameFilesCount()
+        {
+            var gameFiles = CreateTestFileList();
+
+            Assert.IsTrue(database.GetGameFiles().Count() == gameFiles.Count);
+            Assert.IsTrue(database.GetGameFilesCount() == gameFiles.Count);
+            Assert.IsTrue(database.GetGameFileNames().Count() == gameFiles.Count);
+        }
 
         [TestMethod]
-        public void TestGameFileData()
+        public void GetTags_ReturnsTheExpectedTagCount()
         {
-            TestGameFileSelect();
-            TestTagSelect();
-            TestTagMapSelect();
-            TestGameFileTagging();
-            TestGameFileTaggingSearch();
-            TestSelectFields();
-            TestGetFileNameByFileName();
-            TestGetFileNameByID();
-            TestFullLikeFileName();
-            TestPartialLikeFileName();
-            TestPartialLikeFileName_SqlSyntax();
-            TestPartialLikeTitle();
-            TestPartialLikeDescription();
-            TestPartialLikeAuthor();
-            TestUpdateFileName();
-            TestUpdateFields();
-            TestUpdateGameFiles();
-            TestUpdateWhere();
-            TestDelete();
-        }
-
-        public void TestInsertGameFile()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var gameFiles = CreateTestFileList();
-            foreach (var gameFile in gameFiles)
-                adapter.InsertGameFile(gameFile);
-        }
-
-        public void TestInsertTag()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             var tags = CreateTestTagList();
-            foreach (var tag in tags)
-                adapter.InsertTag(tag);
+            Assert.IsTrue(database.GetTags().Count() == tags.Count);
         }
 
-        public void TestInsertTagMap()
+        [TestMethod]
+        public void GetTagMappings_MatchesTheGameFileCount()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var mapTags = CreateTestTagMapping();
-            foreach (var map in mapTags)
-                adapter.InsertTagMapping(map);
-        }
-
-        // Check the number of game files retrieved is the same as saved
-        public void TestGameFileSelect()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var gameFiles = CreateTestFileList();
-
-            Assert.IsTrue(adapter.GetGameFiles().Count() == gameFiles.Count);
-            Assert.IsTrue(adapter.GetGameFilesCount() == gameFiles.Count);
-            Assert.IsTrue(adapter.GetGameFileNames().Count() == gameFiles.Count);
-        }
-
-        // Check the number of Tags retrieved is the same as saved
-        public void TestTagSelect()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var tags = CreateTestTagList();
-            Assert.IsTrue(adapter.GetTags().Count() == tags.Count);
-        }
-
-        // Check the number of TagMappings retrieved is the same as saved, and the same as the number of gamefiles
-        public void TestTagMapSelect()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             var tagMap = CreateTestTagMapping();
-            Assert.IsTrue(adapter.GetTagMappings().Count() == tagMap.Count);
-            Assert.IsTrue(adapter.GetGameFiles().Count() == tagMap.Count);
+            Assert.IsTrue(database.GetTagMappings().Count() == tagMap.Count);
+            Assert.IsTrue(database.GetGameFiles().Count() == tagMap.Count);
         }
 
-        // Check that the number of tags mappings committed for a GameFile is the same as the number saved
-        public void TestGameFileTagging()
+        [TestMethod]
+        public void GetGameFiles_Tag_ReturnsTheExpectedGameFilesCount()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var tags = adapter.GetTags();
-            var tagMap = adapter.GetTagMappings();
+            var tags = database.GetTags();
+            var tagMap = database.GetTagMappings();
 
             foreach (var tag in tags)
             {
-                var gameFileGet = adapter.GetGameFiles(tag);
+                var gameFileGet = database.GetGameFiles(tag);
                 Assert.IsTrue(gameFileGet.Count() == tagMap.Count(x => x.TagID == tag.TagID));
             }
         }
 
-        // ??? Check searching behaviour with various options
-        public void TestGameFileTaggingSearch()
+        [TestMethod]
+        public void GetGameFiles_Options_Tag_ReturnsTheExpectedGameFileCount()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var tags = adapter.GetTags();
-            var tagMap = adapter.GetTagMappings();
+            var tags = database.GetTags();
+            var tagMap = database.GetTagMappings();
 
             foreach (var tag in tags)
             {
-                var gameFileGet = adapter.GetGameFiles(new GameFileGetOptions(s_fields), tag);
+                var gameFileGet = database.GetGameFiles(new GameFileGetOptions(s_fields), tag);
                 Assert.IsTrue(gameFileGet.Count() == tagMap.Count(x => x.TagID == tag.TagID));
             }
 
             foreach (var tag in tags)
             {
                 var options = new GameFileGetOptions(s_fields, new GameFileSearchField(GameFileFieldType.GameFileID, "1"));
-                var gameFileGet = adapter.GetGameFiles(options, tag);
+                var gameFileGet = database.GetGameFiles(options, tag);
                 Assert.IsTrue(gameFileGet.Count() == tagMap.Count(x => x.TagID == tag.TagID && x.FileID == 1));
             }
         }
 
-        // ??? Check searching behaviour with various options
-        public void TestSelectFields()
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsExpectedGameFiles()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             var gameFiles = CreateTestFileList();
 
-            var selectGameFiles = adapter.GetGameFiles(new GameFileGetOptions(s_fields));
+            var selectGameFiles = database.GetGameFiles(new GameFileGetOptions(s_fields));
 
             foreach(var gameFile in gameFiles)
             {
@@ -284,8 +251,8 @@ namespace UnitTest.Tests
             }
         }
 
-        // ??? Check searching behaviour with various options
-        public void TestGetFileNameByFileName()
+        [TestMethod]
+        public void GetFileName_String_ReturnsGameFileOfThatName()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             var gameFiles = CreateTestFileList();
@@ -299,16 +266,15 @@ namespace UnitTest.Tests
             }
         }
 
-        // ??? Check searching behaviour with various options
-        public void TestGetFileNameByID()
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsGameFileById()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             var gameFiles = CreateTestFileList();
 
             foreach (var gameFile in gameFiles)
             {
                 IGameFileGetOptions options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.GameFileID, gameFile.GameFileID.ToString()));
-                var gameFilesFind = adapter.GetGameFiles(options);
+                var gameFilesFind = database.GetGameFiles(options);
 
                 Assert.AreEqual(1, gameFilesFind.Count());
                 Assert.AreEqual(gameFile, gameFilesFind.First()); //Default operator, only checks against FileName
@@ -316,8 +282,8 @@ namespace UnitTest.Tests
             }
         }
 
-        // ??? Check searching behaviour with various options
-        public void TestFullLikeFileName()
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsGameFileLikeFileName()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             var gameFiles = CreateTestFileList();
@@ -325,88 +291,82 @@ namespace UnitTest.Tests
             foreach (var gameFile in gameFiles)
             {
                 IGameFileGetOptions options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Filename, GameFileSearchOp.Like, gameFile.FileName));
-                var gameFilesFind = adapter.GetGameFiles(options);
+                var gameFilesFind = database.GetGameFiles(options);
 
                 Assert.AreEqual(1, gameFilesFind.Count());
                 Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFilesFind.First()));
             }
         }
 
-        // ??? Check searching behaviour with various options
-        public void TestPartialLikeFileName()
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsGameFilePartialLikeFileName()
         {
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             IGameFileGetOptions options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Filename, GameFileSearchOp.Like, "test"));
-            var gameFilesFind = adapter.GetGameFiles(options);
+            var gameFilesFind = database.GetGameFiles(options);
 
             Assert.AreEqual(gameFilesFind.Count(), CreateTestFileList().Count);
         }
 
-        // ??? Check searching behaviour with various options
-        public void TestPartialLikeFileName_SqlSyntax()
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsGameFilePartialLikeFileName_SqlSyntax()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             IGameFileGetOptions options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Filename, GameFileSearchOp.Like, "test" + s_garbage));
-            var gameFilesFind = adapter.GetGameFiles(options);
+            var gameFilesFind = database.GetGameFiles(options);
 
             Assert.AreEqual(3, gameFilesFind.Count());
         }
 
-        // ??? Check searching behaviour with various options
-        public void TestPartialLikeTitle()
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsGameFilePartialLikeTitle()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             IGameFileGetOptions options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Title, GameFileSearchOp.Like, "test"));
-            var gameFilesFind = adapter.GetGameFiles(options);
+            var gameFilesFind = database.GetGameFiles(options);
 
             Assert.AreEqual(gameFilesFind.Count(), CreateTestFileList().Count);
         }
 
-        // ??? Check searching behaviour with various options
-        public void TestPartialLikeDescription()
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsGameFilePartialLikeDescription()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             IGameFileGetOptions options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Description, GameFileSearchOp.Like, "test"));
-            var gameFilesFind = adapter.GetGameFiles(options);
+            var gameFilesFind = database.GetGameFiles(options);
 
             Assert.AreEqual(gameFilesFind.Count(), CreateTestFileList().Count);
         }
 
-        // ??? Check searching behaviour with various options
-        public void TestPartialLikeAuthor()
+        [TestMethod]
+        public void GetGameFiles_Options_ReturnsGameFilePartialLikeAuthor()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             IGameFileGetOptions options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Author, GameFileSearchOp.Like, "test"));
-            var gameFilesFind = adapter.GetGameFiles(options);
+            var gameFilesFind = database.GetGameFiles(options);
 
             Assert.AreEqual(gameFilesFind.Count(), CreateTestFileList().Count);
         }
 
-        // ??? Check searching behaviour with various options
-        public void TestUpdateFileName()
+        [TestMethod]
+        public void UpdateGameFile_UpdatesFileName()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             var gameFiles = CreateTestFileList();
 
             foreach(var gameFile in gameFiles)
             {
                 string oldFileName = gameFile.FileName;
                 gameFile.FileName = gameFile.FileName.Replace(gameFile.GameFileID.ToString(), string.Format("Update_{0}", gameFile.GameFileID));
-                adapter.UpdateGameFile(gameFile, new GameFileFieldType[] { GameFileFieldType.Filename });
+                database.UpdateGameFile(gameFile, new GameFileFieldType[] { GameFileFieldType.Filename });
 
-                IGameFile gameFileFind = adapter.GetGameFile(oldFileName);
+                IGameFile gameFileFind = database.GetGameFile(oldFileName);
                 Assert.IsTrue(gameFileFind == null);
 
-                gameFileFind = adapter.GetGameFile(gameFile.FileName);
+                gameFileFind = database.GetGameFile(gameFile.FileName);
                 Assert.AreEqual(gameFile, gameFileFind);
                 Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFileFind));
             }
         }
 
-        // ??? 
-        public void TestUpdateFields()
+        [TestMethod]
+        public void UpdateGameFile_UpdatesSpecifiedFields()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             var gameFiles = CreateTestFileList();
 
             List<GameFileFieldType> fields = new List<GameFileFieldType>();
@@ -420,53 +380,52 @@ namespace UnitTest.Tests
 
             foreach (var gameFile in gameFiles)
             {
-                adapter.UpdateGameFile(gameFile, fields.ToArray());
-                IGameFile gameFileFind = adapter.GetGameFile(gameFile.FileName);
+                database.UpdateGameFile(gameFile, fields.ToArray());
+                IGameFile gameFileFind = database.GetGameFile(gameFile.FileName);
                 Assert.IsTrue(gameFileFind != null);
                 Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFileFind));
             }
         }
 
-
-        public void TestUpdateGameFiles()
+        [TestMethod]
+        public void UpdateGameFile_UpdatesAllFields()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             var gameFiles = CreateTestFileList();
             SetRandomFileValues(gameFiles, typeof(GameFile).GetProperties());
 
             foreach(var gameFile in gameFiles)
             {
-                adapter.UpdateGameFile(gameFile);
-                IGameFile gameFileFind = adapter.GetGameFile(gameFile.FileName);
+                database.UpdateGameFile(gameFile);
+                IGameFile gameFileFind = database.GetGameFile(gameFile.FileName);
                 Assert.IsTrue(gameFileFind != null);
                 Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFileFind));
             }
         }
 
-        public void TestUpdateWhere()
+        [TestMethod]
+        public void UpdateGameFile_UpdatesConditionally()
         {
             //Note: This function is only used in SourcePortViewForm.cs
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             var gameFiles = CreateTestFileList();
             int test = 1000;
 
             foreach(var gameFile in gameFiles)
             {
-                adapter.UpdateGameFile(gameFile); //Make sure we're in sync with our test list first...
+                database.UpdateGameFile(gameFile); //Make sure we're in sync with our test list first...
 
                 //Test setting a real value
-                adapter.UpdateGameFiles(GameFileFieldType.SourcePortID, GameFileFieldType.SourcePortID, gameFile.SourcePortID, test);
+                database.UpdateGameFiles(GameFileFieldType.SourcePortID, GameFileFieldType.SourcePortID, gameFile.SourcePortID, test);
                 gameFile.SourcePortID = test;
 
-                IGameFile gameFileFind = adapter.GetGameFile(gameFile.FileName);
+                IGameFile gameFileFind = database.GetGameFile(gameFile.FileName);
                 Assert.IsTrue(gameFileFind != null);
                 Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFileFind));
 
                 //Test setting value to null
-                adapter.UpdateGameFiles(GameFileFieldType.SourcePortID, GameFileFieldType.SourcePortID, gameFile.SourcePortID, null);
+                database.UpdateGameFiles(GameFileFieldType.SourcePortID, GameFileFieldType.SourcePortID, gameFile.SourcePortID, null);
                 gameFile.SourcePortID = null;
 
-                gameFileFind = adapter.GetGameFile(gameFile.FileName);
+                gameFileFind = database.GetGameFile(gameFile.FileName);
                 Assert.IsTrue(gameFileFind != null);
                 Assert.IsTrue(TestUtil.AllFieldsEqual<IGameFile>(gameFile, gameFileFind));
 
@@ -504,19 +463,19 @@ namespace UnitTest.Tests
             }
         }
 
-        public void TestDelete()
+        [TestMethod]
+        public void DeleteGameFile_DeletesFile()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             var gameFiles = CreateTestFileList();
             int count = gameFiles.Count;
 
             foreach (var gameFile in gameFiles)
             {
-                adapter.DeleteGameFile(gameFile);
+                database.DeleteGameFile(gameFile);
 
-                IGameFile gameFileFind = adapter.GetGameFile(gameFile.FileName);
+                IGameFile gameFileFind = database.GetGameFile(gameFile.FileName);
                 Assert.IsTrue(gameFileFind == null);
-                Assert.AreEqual(adapter.GetGameFiles().Count(), --count);
+                Assert.AreEqual(database.GetGameFiles().Count(), --count);
             }
         }
     }

--- a/UnitTest/Tests/TestGameFileTags.cs
+++ b/UnitTest/Tests/TestGameFileTags.cs
@@ -1,0 +1,201 @@
+﻿using DoomLauncher;
+using DoomLauncher.DataSources;
+using DoomLauncher.Interfaces;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace UnitTest.Tests
+{
+    [TestClass]
+    public class TestGameFileTags
+    {
+        private IDataSourceAdapter database;
+
+        private GameFile CreateGameFile(string filename)
+        {
+            DateTime dt = DateTime.Parse("1/1/17");
+
+            GameFile gameFile = new GameFile
+            {
+                FileName = filename,
+                Author = "the author",
+                Description = "the description",
+                Title = "the title",
+                Comments = "the comments",
+                ReleaseDate = dt,
+                Downloaded = dt,
+                LastPlayed = dt,
+                IWadID = 22,
+                Rating = 33,
+                MinutesPlayed = 44,
+                MapCount = 55,
+                SourcePortID = 66,
+                SettingsExtraParams = "the extra params",
+                SettingsFiles = "the settings files",
+                SettingsFilesIWAD = "the settings files iwad",
+                SettingsFilesSourcePort = "the settings files source port",
+                SettingsMap = "the settings map",
+                SettingsSkill = "the settings skill",
+                SettingsSpecificFiles = "the settings specific files",
+                SettingsGameProfileID = 567
+            };
+
+            return gameFile;
+        }
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            database = TestUtil.CreateAdapter();
+        }
+
+        [TestCleanup]
+        public void CleanDatabase()
+        {
+            var dataAccess = ((DbDataSourceAdapter)database).DataAccess;
+            dataAccess.ExecuteNonQuery("delete from GameFiles");
+            dataAccess.ExecuteNonQuery("delete from Tags");
+            dataAccess.ExecuteNonQuery("delete from TagMapping");
+        }
+
+        [TestMethod]
+        public void GetTags_ReturnsAllTags()
+        {
+            var gameFile1 = CreateGameFile("foo.zip");
+
+            var tag1 = new TagData
+            {
+                Name = "Cool maps",
+                HasTab = true,
+                HasColor = true,
+                Color = 0xff00ff,
+                ExcludeFromOtherTabs = true,
+            };
+
+            var tag2 = new TagData
+            {
+                Name = "Cool bananas",
+                HasTab = false,
+                HasColor = false,
+                Color = null,
+                ExcludeFromOtherTabs = false,
+            };
+
+
+            database.InsertTag(tag1);
+            database.InsertTag(tag2);
+
+            var tags = database.GetTags();
+
+            var retrievedTag1 = tags.Where(x => x.Name.Equals(tag1.Name)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(tag1, retrievedTag1, "TagID"));
+
+            var retrievedTag2 = tags.Where(x => x.Name.Equals(tag2.Name)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(tag2, retrievedTag2, "TagID"));
+        }
+
+        [TestMethod]
+        public void GetTagMappings_ReturnsAllTagMappings()
+        {
+            var tagMapping1 = new TagMapping
+            {
+                TagID = 1,
+                FileID = 2
+            };
+
+            var tagMapping2 = new TagMapping
+            {
+                TagID = 77,
+                FileID = 44
+            };
+
+            database.InsertTagMapping(tagMapping1);
+            database.InsertTagMapping(tagMapping2);
+
+            var tagMappings = database.GetTagMappings();
+
+            var retrievedTagMapping1 = tagMappings.Where(x => x.TagID.Equals(tagMapping1.TagID)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqual(tagMapping1, retrievedTagMapping1));
+
+            var retrievedTagMapping2 = tagMappings.Where(x => x.TagID.Equals(tagMapping2.TagID)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqual(tagMapping2, retrievedTagMapping2));
+        }
+
+        [TestMethod]
+        public void GetGameFiles_Tag_ReturnsMatchingGameFiles()
+        {
+            var taggedFile = CreateGameFile("taggy.zip");
+            var wrongFile = CreateGameFile("wrong.zip");
+
+            var tag = new TagData { Name = "Fave" };
+
+            database.InsertGameFile(taggedFile);
+            database.InsertGameFile(wrongFile);
+            database.InsertTag(tag);
+
+            var retrievedGameFile1 = database.GetGameFile("taggy.zip");
+            var retrievedTag = database.GetTags().First();
+
+            database.InsertTagMapping(new TagMapping()
+            {
+                TagID = retrievedTag.TagID,
+                FileID = (int)retrievedGameFile1.GameFileID
+            });
+
+            var retrievedGameFiles = database.GetGameFiles(retrievedTag);
+            Assert.AreEqual(1, retrievedGameFiles.Count());
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(taggedFile, retrievedGameFiles.First(), "GameFileID"));
+        }
+
+        [TestMethod]
+        public void GetGameFiles_Options_Tag_ReturnsMatchingTaggedGameFiles()
+        {
+            var rightTaggedFile = CreateGameFile("right_tagged.zip");
+            rightTaggedFile.Description = "Robots";
+
+            var rightUntaggedFile = CreateGameFile("right_untagged.zip");
+            rightUntaggedFile.Description = "Robots";
+
+            var wrongTaggedFile = CreateGameFile("wrong_tagged.zip");
+            var wrongUntaggedFile = CreateGameFile("wrong_untagged.zip");
+
+            var tag = new TagData { Name = "Wow" };
+
+            database.InsertGameFile(rightTaggedFile);
+            database.InsertGameFile(rightUntaggedFile);
+            database.InsertGameFile(wrongTaggedFile);
+            database.InsertGameFile(wrongUntaggedFile);
+            database.InsertTag(tag);
+
+            var retrievedRightTaggedFile = database.GetGameFile("right_tagged.zip");
+            var retrievedWrongTaggedFile = database.GetGameFile("wrong_tagged.zip");
+            var retrievedTag = database.GetTags().First();
+
+            database.InsertTagMapping(new TagMapping()
+            {
+                TagID = retrievedTag.TagID,
+                FileID = (int)retrievedRightTaggedFile.GameFileID
+            });
+
+            database.InsertTagMapping(new TagMapping()
+            {
+                TagID = retrievedTag.TagID,
+                FileID = (int)retrievedWrongTaggedFile.GameFileID
+            });
+
+            var options = new GameFileGetOptions(new GameFileSearchField(GameFileFieldType.Description, GameFileSearchOp.Equal, "Robots"));
+            var retrievedGameFiles = database.GetGameFiles(options, retrievedTag);
+
+
+            Assert.AreEqual(1, retrievedGameFiles.Count());
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(rightTaggedFile, retrievedGameFiles.First(), "GameFileID"));
+        }
+
+    }
+}

--- a/UnitTest/Tests/TestIWad.cs
+++ b/UnitTest/Tests/TestIWad.cs
@@ -1,0 +1,147 @@
+﻿using DoomLauncher;
+using DoomLauncher.DataSources;
+using DoomLauncher.Interfaces;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace UnitTest.Tests
+{
+    [TestClass]
+    public class TestIWad
+    {
+        private IIWadDataSourceAdapter database;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            database = TestUtil.CreateAdapter();
+        }
+
+        [TestCleanup]
+        public void CleanDatabase()
+        {
+            var dataAccess = ((DbDataSourceAdapter)database).DataAccess;
+            dataAccess.ExecuteNonQuery("delete from IWads");
+        }
+
+        [TestMethod]
+        public void GetIWads_ReturnsAllIWads()
+        {
+            var iWad1 = new IWadData()
+            {
+                FileName = "Doom.wad",
+                Name = "Doom",
+                GameFileID = 1
+            };
+
+            var iWad2 = new IWadData()
+            {
+                FileName = "Doom2.wad",
+                Name = "Doom II",
+                GameFileID = 2
+            };
+
+            database.InsertIWad(iWad1);
+            database.InsertIWad(iWad2);
+
+            var iWads = database.GetIWads();
+            Assert.AreEqual(2, iWads.Count());
+
+            var retrieved1 = iWads.Where(x => x.FileName.Equals(iWad1.FileName)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(iWad1, retrieved1, "IWadID"));
+
+            var retrieved2 = iWads.Where(x => x.FileName.Equals(iWad2.FileName)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(iWad2, retrieved2, "IWadID"));
+        }
+
+        [TestMethod]
+        public void GetIWad_GetsIWadForGameFileID()
+        {
+            var iWad1 = new IWadData()
+            {
+                FileName = "Heretic.wad",
+                Name = "Heretic",
+                GameFileID = 5
+            };
+
+            database.InsertIWad(iWad1);
+
+            var retrievedIWad = database.GetIWad(5);
+
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(iWad1, retrievedIWad, "IWadID"));
+        }
+
+        [TestMethod]
+        public void DeleteIWad_DeletesTheIWad()
+        {
+            var iWad1 = new IWadData()
+            {
+                FileName = "plutonia.wad",
+                Name = "The Plutonia Experiment",
+                GameFileID = 3
+            };
+
+            var wrongIWad = new IWadData()
+            {
+                FileName = "tnt.wad",
+                Name = "TNT Evilution",
+                GameFileID = 4
+            };
+
+            database.InsertIWad(iWad1);
+            database.InsertIWad(wrongIWad);
+
+            // Need to fetch so that the primary key is populated.
+            var savedIWad1 = database.GetIWad(3);
+            database.DeleteIWad(savedIWad1);
+
+            var iWads = database.GetIWads();
+            Assert.AreEqual(1, iWads.Count());
+
+            var retrieved2 = iWads.First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(wrongIWad, retrieved2, "IWadID"));
+        }
+
+        [TestMethod]
+        public void UpdateIWad_UpdatesTheRightFieldsInTheRightIWad()
+        {
+            var iWad1 = new IWadData()
+            {
+                FileName = "heretic.wad",
+                Name = "Heretic",
+                GameFileID = 5
+            };
+
+            var wrongIWad = new IWadData()
+            {
+                FileName = "chex.wad",
+                Name = "Chex Quest",
+                GameFileID = 6
+            };
+
+            database.InsertIWad(iWad1);
+            database.InsertIWad(wrongIWad);
+
+            // Need to fetch so that the primary key is populated.
+            var savedIWad1 = database.GetIWad(5);
+            savedIWad1.FileName = "daikatana.wad";
+            savedIWad1.Name = "Daikatana";
+            savedIWad1.GameFileID = 7;
+            database.UpdateIWad(savedIWad1);
+
+            var updatedIWads = database.GetIWads();
+            Assert.AreEqual(2, updatedIWads.Count());
+
+            var retrieved1 = updatedIWads.Where(x => x.IWadID.Equals(savedIWad1.IWadID)).First();
+            Assert.AreEqual("daikatana.wad", retrieved1.FileName);
+            Assert.AreEqual("Daikatana", retrieved1.Name);
+            Assert.AreEqual(7, retrieved1.GameFileID);
+
+            var retrieved2 = updatedIWads.Where(x => x.FileName.Equals(wrongIWad.FileName)).First();
+            Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(wrongIWad, retrieved2, "IWadID"));
+        }
+    }
+}

--- a/UnitTest/Tests/TestLoadFiles.cs
+++ b/UnitTest/Tests/TestLoadFiles.cs
@@ -9,6 +9,7 @@ using System.Linq;
 
 namespace UnitTest.Tests
 {
+    // TODO isolate
     [TestClass]
     public class TestLoadFiles
     {
@@ -16,11 +17,15 @@ namespace UnitTest.Tests
         private static string[] s_files = new string[] { "GAMEFILE1.WAD", "GAMEFILE2.WAD", "GAMEFILE3.WAD" };
         private static string[] s_mods = new string[] { "SUPERCOOLMOD.WAD", "MOD2.WAD", "MOD3.WAD", "MOD4.WAD", "PORTMOD1.WAD", "PORTMOD2.WAD", "IWADMOD1.WAD", "IWADMODZ.WAD" };
 
+        [TestInitialize]
+        public void Initialize()
+        {
+            CreateDatabase();
+        }
+
         [TestMethod]
         public void TestFiles()
         {
-            CreateDatabase();
-
             IDataSourceAdapter adapter = TestUtil.CreateAdapter();
             var gameFiles = Util.GetAdditionalFiles(adapter, (GameFile)adapter.GetGameFile("COOLGAMEFILE.WAD"));
 

--- a/UnitTest/Tests/TestLoadFiles.cs
+++ b/UnitTest/Tests/TestLoadFiles.cs
@@ -2,393 +2,507 @@
 using DoomLauncher.DataSources;
 using DoomLauncher.Handlers;
 using DoomLauncher.Interfaces;
+using DoomLauncher.SourcePort;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Forms;
 
 namespace UnitTest.Tests
 {
-    // TODO isolate
     [TestClass]
     public class TestLoadFiles
     {
-        private static string[] s_iwads = new string[] { "DOOM.WAD", "DOOM2.WAD", "TNT.WAD" };
-        private static string[] s_files = new string[] { "GAMEFILE1.WAD", "GAMEFILE2.WAD", "GAMEFILE3.WAD" };
-        private static string[] s_mods = new string[] { "SUPERCOOLMOD.WAD", "MOD2.WAD", "MOD3.WAD", "MOD4.WAD", "PORTMOD1.WAD", "PORTMOD2.WAD", "IWADMOD1.WAD", "IWADMODZ.WAD" };
+        IDataSourceAdapter database;
 
         [TestInitialize]
         public void Initialize()
         {
-            CreateDatabase();
+            database = TestUtil.CreateAdapter();
+        }
+
+        [TestCleanup]
+        public void CleanDatabase()
+        {
+            var dataAccess = ((DbDataSourceAdapter)database).DataAccess;
+            dataAccess.ExecuteNonQuery("delete from GameFiles");
+            dataAccess.ExecuteNonQuery("delete from IWads");
+            dataAccess.ExecuteNonQuery("delete from SourcePorts");
         }
 
         [TestMethod]
-        public void TestFiles()
+        public void GetIWadFiles_ReturnsFilesDirectlyAssociatedWithTheIWad()
         {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var gameFiles = Util.GetAdditionalFiles(adapter, (GameFile)adapter.GetGameFile("COOLGAMEFILE.WAD"));
-
-            Assert.AreEqual(3, gameFiles.Count);
-            Assert.IsNotNull(gameFiles.First(x => x.FileName == "COOLGAMEFILE.WAD"));
-            Assert.IsNotNull(gameFiles.First(x => x.FileName == "SUPERCOOLMOD.WAD"));
-            Assert.IsNotNull(gameFiles.First(x => x.FileName == "MOD2.WAD"));
-
-            gameFiles = Util.GetAdditionalFiles(adapter, (GameFile)adapter.GetGameFile("OTHERGAMEFILE.WAD"));
-            Assert.AreEqual(3, gameFiles.Count);
-            Assert.IsNotNull(gameFiles.First(x => x.FileName == "OTHERGAMEFILE.WAD"));
-            Assert.IsNotNull(gameFiles.First(x => x.FileName == "MOD3.WAD"));
-            Assert.IsNotNull(gameFiles.First(x => x.FileName == "MOD4.WAD"));
-
-            gameFiles = Util.GetAdditionalFiles(adapter, adapter.GetSourcePorts().First(x => x.Name == "zdoom.exe"));
-            Assert.AreEqual(1, gameFiles.Count);
-            Assert.IsNotNull(gameFiles.First(x => x.FileName == "PORTMOD1.WAD"));
-        }
-
-        [TestMethod]
-        public void TestSimpleFileWithIwad()
-        {
-            //This was a bug, for an iwad like DOOM2 Doom Launcher sets the SettingsFile to DOOM2.WAD if the user loaded it. We need to exclude this when using DOOM2 as the iwad for another file
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var iwad = adapter.GetGameFileIWads().First(x => x.FileName == "DOOM2.WAD");
-            iwad.SettingsFiles = "DOOM2.WAD";
-            adapter.UpdateGameFile(iwad);
-
-            FileLoadHandler handler = new FileLoadHandler(adapter, adapter.GetGameFile("COOLGAMEFILE.WAD"));
-
-            iwad = adapter.GetGameFileIWads().First(x => x.FileName == "DOOM2.WAD"); 
-            var sourceport = adapter.GetSourcePorts().First(x => x.Name == "zdoom.exe");
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-
-            Assert.IsNull(handler.GetCurrentAdditionalFiles().FirstOrDefault(x => x.FileName == "DOOM2.WAD"));
-        }
-
-        [TestMethod]
-        public void TestHandlerSourcePort()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            FileLoadHandler handler = new FileLoadHandler(adapter, adapter.GetGameFile("COOLGAMEFILE.WAD"));
-            Assert.AreEqual(3, handler.GetCurrentAdditionalFiles().Count);
-
-            var iwad = adapter.GetGameFileIWads().First(x => x.FileName == "DOOM.WAD"); //no additional files for iwad
-            var sourceport = adapter.GetSourcePorts().First(x => x.Name == "zdoom.exe");
-
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            var gameFiles = handler.GetCurrentAdditionalFiles();
-
-            Assert.AreEqual(4, gameFiles.Count);
-            Assert.IsNotNull(gameFiles.FirstOrDefault(x => x.FileName == "PORTMOD1.WAD"));
-
-            //no change
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            gameFiles = handler.GetCurrentAdditionalFiles();
-
-            Assert.IsNotNull(gameFiles.First(x => x.FileName == "PORTMOD1.WAD"));
-
-            Assert.IsFalse(handler.IsIWadFile(gameFiles.First(x => x.FileName == "PORTMOD1.WAD")));
-            Assert.IsTrue(handler.IsSourcePortFile(gameFiles.First(x => x.FileName == "PORTMOD1.WAD")));
-        }
-
-        [TestMethod]
-        public void TestHandlerIWad()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            FileLoadHandler handler = new FileLoadHandler(adapter, adapter.GetGameFile("COOLGAMEFILE.WAD"));
-            Assert.AreEqual(3, handler.GetCurrentAdditionalFiles().Count);
-
-            var iwad = adapter.GetGameFileIWads().First(x => x.FileName == "PLUTONIA.WAD");
-            var sourceport = adapter.GetSourcePorts().First(x => x.Name == "odamex.exe"); //no additional files for port
-
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            var gameFiles = handler.GetCurrentAdditionalFiles();
-
-            Assert.AreEqual(4, gameFiles.Count);
-            Assert.IsNotNull(gameFiles.FirstOrDefault(x => x.FileName == "IWADMOD1.WAD"));
-
-            //no change
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            gameFiles = handler.GetCurrentAdditionalFiles();
-
-            Assert.IsNotNull(gameFiles.FirstOrDefault(x => x.FileName == "IWADMOD1.WAD"));
-
-            Assert.IsTrue(handler.IsIWadFile(gameFiles.First(x => x.FileName == "IWADMOD1.WAD")));
-            Assert.IsFalse(handler.IsSourcePortFile(gameFiles.First(x => x.FileName == "IWADMOD1.WAD")));
-        }
-
-        [TestMethod]
-        public void TestHandlerMixed()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            FileLoadHandler handler = new FileLoadHandler(adapter, adapter.GetGameFile("COOLGAMEFILE.WAD"));
-            Assert.AreEqual(3, handler.GetCurrentAdditionalFiles().Count);
-
-            var iwad = adapter.GetGameFileIWads().First(x => x.FileName == "PLUTONIA.WAD");
-            var sourceport = adapter.GetSourcePorts().First(x => x.Name == "zdoom.exe");
-
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            var gameFiles = handler.GetCurrentAdditionalFiles();
-
-            Assert.AreEqual(5, gameFiles.Count);
-            Assert.IsNotNull(gameFiles.First(x => x.FileName == "IWADMOD1.WAD"));
-            Assert.IsNotNull(gameFiles.First(x => x.FileName == "PORTMOD1.WAD"));
-
-            Assert.IsTrue(handler.IsIWadFile(gameFiles.First(x => x.FileName == "IWADMOD1.WAD")));
-            Assert.IsTrue(handler.IsSourcePortFile(gameFiles.First(x => x.FileName == "PORTMOD1.WAD")));
-        }
-
-        [TestMethod]
-        public void TestHandlerOrder()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var mainFile = adapter.GetGameFile("COOLGAMEFILE.WAD");
-            FileLoadHandler handler = new FileLoadHandler(adapter, mainFile);
-            Assert.AreEqual(3, handler.GetCurrentAdditionalFiles().Count);
-
-            var iwad = adapter.GetGameFileIWads().First(x => x.FileName == "PLUTONIA.WAD");
-            var sourceport = adapter.GetSourcePorts().First(x => x.Name == "zdoom.exe");
-
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            var gameFiles = handler.GetCurrentAdditionalFiles();
-
-            Assert.AreEqual(5, gameFiles.Count);
-            Assert.AreEqual("COOLGAMEFILE.WAD", gameFiles[0].FileName);
-            Assert.AreEqual("SUPERCOOLMOD.WAD", gameFiles[1].FileName);
-            Assert.AreEqual("MOD2.WAD", gameFiles[2].FileName);
-            Assert.AreEqual("IWADMOD1.WAD", gameFiles[3].FileName);
-            Assert.AreEqual("PORTMOD1.WAD", gameFiles[4].FileName);
-
-            //user changed the order - the files should be returned in the order the user set
-            string newOrder = "IWADMOD1.WAD;SUPERCOOLMOD.WAD;PORTMOD1.WAD;MOD2.WAD";
-            mainFile.SettingsFiles = newOrder;
-            handler = new FileLoadHandler(adapter, mainFile);
-
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            gameFiles = handler.GetCurrentAdditionalFiles();
-
-            Assert.AreEqual(5, gameFiles.Count);
-            Assert.AreEqual("COOLGAMEFILE.WAD", gameFiles[0].FileName);
-            Assert.AreEqual("IWADMOD1.WAD", gameFiles[1].FileName);
-            Assert.AreEqual("SUPERCOOLMOD.WAD", gameFiles[2].FileName);
-            Assert.AreEqual("PORTMOD1.WAD", gameFiles[3].FileName);
-            Assert.AreEqual("MOD2.WAD", gameFiles[4].FileName);
-
-            //change source port - PORTMOD1 will be removed, PORTMOD2 should be added last
-            sourceport = adapter.GetSourcePorts().First(x => x.Name == "prboom.exe");
-
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            gameFiles = handler.GetCurrentAdditionalFiles();
-
-            Assert.AreEqual(5, gameFiles.Count);
-            Assert.AreEqual("COOLGAMEFILE.WAD", gameFiles[0].FileName);
-            Assert.AreEqual("IWADMOD1.WAD", gameFiles[1].FileName);
-            Assert.AreEqual("SUPERCOOLMOD.WAD", gameFiles[2].FileName);
-            Assert.AreEqual("MOD2.WAD", gameFiles[3].FileName);
-            Assert.AreEqual("PORTMOD2.WAD", gameFiles[4].FileName);
-
-            //change iwad - IWADMOD1 should be removed
-            iwad = adapter.GetGameFileIWads().First(x => x.FileName == "DOOM2.WAD");
-
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            gameFiles = handler.GetCurrentAdditionalFiles();
-
-            Assert.AreEqual(4, gameFiles.Count);
-            Assert.AreEqual("COOLGAMEFILE.WAD", gameFiles[0].FileName);
-            Assert.AreEqual("SUPERCOOLMOD.WAD", gameFiles[1].FileName);
-            Assert.AreEqual("MOD2.WAD", gameFiles[2].FileName);
-            Assert.AreEqual("PORTMOD2.WAD", gameFiles[3].FileName);
-
-            //set source port back - order has chaged, PORTMOD1 will be last
-            sourceport = adapter.GetSourcePorts().First(x => x.Name == "zdoom.exe");
-
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            gameFiles = handler.GetCurrentAdditionalFiles();
-
-            Assert.AreEqual(4, gameFiles.Count);
-            Assert.AreEqual("COOLGAMEFILE.WAD", gameFiles[0].FileName);
-            Assert.AreEqual("SUPERCOOLMOD.WAD", gameFiles[1].FileName);
-            Assert.AreEqual("MOD2.WAD", gameFiles[2].FileName);
-            Assert.AreEqual("PORTMOD1.WAD", gameFiles[3].FileName);
-
-            //RESET - should load original files, but with new order specified in the gamefile
-            handler.Reset();
-
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            gameFiles = handler.GetCurrentAdditionalFiles();
-
-            Assert.AreEqual(5, gameFiles.Count);
-            Assert.AreEqual("COOLGAMEFILE.WAD", gameFiles[0].FileName);
-            Assert.AreEqual("IWADMOD1.WAD", gameFiles[1].FileName);
-            Assert.AreEqual("SUPERCOOLMOD.WAD", gameFiles[2].FileName);
-            Assert.AreEqual("PORTMOD1.WAD", gameFiles[3].FileName);
-            Assert.AreEqual("MOD2.WAD", gameFiles[4].FileName);
-        }
-
-        [TestMethod]
-        public void TestIWadExclude()
-        {
-            //if the iwad has a file attached to it because of a source port, that file should not be included when the iwad is selected
-            //e.g. GZDoom has noendgame.wad User launched DOOM2.WAD with GZDoom. This adds noendgame to the additional files of DOOM2.WAD.
-            //if the user selects DOOM2.WAD with another file (and not GZDoom as the port), noendgame.wad should not be added
-
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var mainFile = adapter.GetGameFile("COOLGAMEFILE.WAD");
-            FileLoadHandler handler = new FileLoadHandler(adapter, mainFile);
-            Assert.AreEqual(3, handler.GetCurrentAdditionalFiles().Count);
-
-            var iwad = adapter.GetGameFileIWads().First(x => x.FileName == "DOOM2.WAD");
-            var sourceport = adapter.GetSourcePorts().First(x => x.Name == "zdoom.exe");
-
-            iwad.SettingsFiles = "MOD4.WAD";
-            adapter.UpdateGameFile(iwad);
-
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            var gameFiles = handler.GetCurrentAdditionalFiles();
-            Assert.AreEqual(5, gameFiles.Count);
-            Assert.IsNotNull(gameFiles.FirstOrDefault(x => x.FileName == "MOD4.WAD"));
-
-            //now set up the file so it should be excluded
-            iwad.SettingsFilesSourcePort = "MOD4.WAD";
-            adapter.UpdateGameFile(iwad);
-
-            handler = new FileLoadHandler(adapter, mainFile);
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            gameFiles = handler.GetCurrentAdditionalFiles();
-            Assert.AreEqual(4, gameFiles.Count);
-            Assert.IsNull(gameFiles.FirstOrDefault(x => x.FileName == "MOD4.WAD"));
-        }
-
-        [TestMethod]
-        public void TestIwadWithModsFirst()
-        {
-            // Testing the feature where if files put before the iwad they should be put before this file
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var mainFile = adapter.GetGameFile("GAMEFILE1.WAD");
-            FileLoadHandler handler = new FileLoadHandler(adapter, mainFile);
-            Assert.AreEqual(1, handler.GetCurrentAdditionalFiles().Count);
-
-            var iwad = adapter.GetGameFileIWads().First(x => x.FileName == "FIRSTIWAD.WAD");
-            var sourceport = adapter.GetSourcePorts().First(x => x.Name == "zdoom.exe");
-
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            var gameFiles = handler.GetCurrentAdditionalFiles();
-            Assert.AreEqual(3, gameFiles.Count);
-            Assert.AreEqual("IWADMODZ.WAD", gameFiles[0].FileName);
-            Assert.AreEqual("GAMEFILE1.WAD", gameFiles[1].FileName);
-            Assert.AreEqual("PORTMOD1.WAD", gameFiles[2].FileName);
-        }
-
-        [TestMethod]
-        public void TestUserSet()
-        {
-            //base test
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-            var mainFile = adapter.GetGameFile("COOLGAMEFILE.WAD");
-            FileLoadHandler handler = new FileLoadHandler(adapter, mainFile);
-            Assert.AreEqual(3, handler.GetCurrentAdditionalFiles().Count);
-
-            var iwad = adapter.GetGameFileIWads().First(x => x.FileName == "PLUTONIA.WAD");
-            var sourceport = adapter.GetSourcePorts().First(x => x.Name == "zdoom.exe");
-
-            handler.CalculateAdditionalFiles(iwad, sourceport);
-            var gameFiles = handler.GetCurrentAdditionalFiles();
-
-            Assert.AreEqual(5, gameFiles.Count);
-            Assert.AreEqual("COOLGAMEFILE.WAD", gameFiles[0].FileName);
-            Assert.AreEqual("SUPERCOOLMOD.WAD", gameFiles[1].FileName);
-            Assert.AreEqual("MOD2.WAD", gameFiles[2].FileName);
-            Assert.AreEqual("IWADMOD1.WAD", gameFiles[3].FileName);
-            Assert.AreEqual("PORTMOD1.WAD", gameFiles[4].FileName);
-
-            //**user removes iwad add file
-            var addFiles = handler.GetCurrentAdditionalFiles();
-            addFiles.RemoveAll(x => x.FileName == "IWADMOD1.WAD");
-            SetAddFiles(mainFile, handler, addFiles);
-
-            handler = new FileLoadHandler(adapter, mainFile);
-            //do not call calculate, this will reset user set files
-            gameFiles = handler.GetCurrentAdditionalFiles();
-
-            Assert.AreEqual(4, gameFiles.Count);
-            Assert.AreEqual("COOLGAMEFILE.WAD", gameFiles[0].FileName);
-            Assert.AreEqual("SUPERCOOLMOD.WAD", gameFiles[1].FileName);
-            Assert.AreEqual("MOD2.WAD", gameFiles[2].FileName);
-            Assert.AreEqual("PORTMOD1.WAD", gameFiles[3].FileName);
-
-            //**user removes source port add file
-            addFiles = handler.GetCurrentAdditionalFiles();
-            addFiles.RemoveAll(x => x.FileName == "PORTMOD1.WAD");
-            SetAddFiles(mainFile, handler, addFiles);
-
-            handler = new FileLoadHandler(adapter, mainFile);
-            //do not call calculate, this will reset user set files
-            gameFiles = handler.GetCurrentAdditionalFiles();
-
-            Assert.AreEqual(3, gameFiles.Count);
-            Assert.AreEqual("COOLGAMEFILE.WAD", gameFiles[0].FileName);
-            Assert.AreEqual("SUPERCOOLMOD.WAD", gameFiles[1].FileName);
-            Assert.AreEqual("MOD2.WAD", gameFiles[2].FileName);
-        }
-
-        private static void SetAddFiles(IGameFile mainFile, FileLoadHandler handler, List<IGameFile> addFiles)
-        {
-            mainFile.SettingsFiles = string.Join(";", addFiles.Select(x => x.FileName));
-            mainFile.SettingsFilesIWAD = string.Join(";", addFiles.Intersect(handler.GetIWadFiles()).Select(x => x.FileName));
-            mainFile.SettingsFilesSourcePort = string.Join(";", addFiles.Intersect(handler.GetSourcePortFiles()).Select(x => x.FileName));
-        }
-
-        private void CreateDatabase()
-        {
-            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
-
-            Array.ForEach(s_iwads, x => CreateGameFile(adapter, x, true, string.Empty));
-            Array.ForEach(s_files, x => CreateGameFile(adapter, x, false, string.Empty));
-            Array.ForEach(s_mods, x => CreateGameFile(adapter, x, false, string.Empty));
-            CreateGameFile(adapter, "PLUTONIA.WAD", true, "IWADMOD1.WAD");
-            CreateGameFile(adapter, "FIRSTIWAD.WAD", true, "IWADMODZ.WAD", addFilesFirst: true);
-            CreateGameFile(adapter, "COOLGAMEFILE.WAD", false, "SUPERCOOLMOD.WAD;MOD2.WAD;");
-            CreateGameFile(adapter, "OTHERGAMEFILE.WAD", false, "MOD3.WAD;MOD4.WAD;");
-            CreateSourcePort(adapter, "zdoom.exe", "PORTMOD1.WAD");
-            CreateSourcePort(adapter, "prboom.exe", "PORTMOD2.WAD");
-            CreateSourcePort(adapter, "odamex.exe", string.Empty);
-        }
-
-        private static void CreateGameFile(IDataSourceAdapter adapter, string name, bool isiwad, string addfiles, bool addFilesFirst = false)
-        {
-            GameFile gameFile = new GameFile()
+            var gameProfile = new GameFile
             {
-                FileName = name,
-                Title = name,
-                SettingsFiles = addFilesFirst ? string.Concat(addfiles, ";", name) : string.Concat(name, ";", addfiles)
+                FileName = "foo.wad",
+                SettingsFilesIWAD = "green.wad;blue.wad"
             };
+            database.InsertGameFile(gameProfile);
 
-            adapter.InsertGameFile(gameFile);
+            var gameFile1 = new GameFile // Won't get used
+            { 
+                FileName = "whocares.wad",
+                SettingsFilesIWAD = "nope.wad"
+            }; 
+            database.InsertGameFile(gameFile1);
 
-            if (isiwad)
-            {
-                IWadData iwad = new IWadData()
-                {
-                    FileName = name,
-                    Name = name,
-                    GameFileID = adapter.GetGameFile(name).GameFileID
-                };
+            var gameFile2 = new GameFile { FileName = "green.wad" };
+            database.InsertGameFile(gameFile2);
 
-                adapter.InsertIWad(iwad);
-            }
+            var gameFile3 = new GameFile { FileName = "blue.wad" };
+            database.InsertGameFile(gameFile3);
+
+            var wrongGameFile = new GameFile { FileName = "nope.wad" };
+            database.InsertGameFile(wrongGameFile);
+
+            var fileLoadHandler = new FileLoadHandler(database, gameFile1, gameProfile);
+            var iwadFiles = fileLoadHandler.GetIWadFiles();
+            Assert.AreEqual(2, iwadFiles.Count);
+            Assert.IsTrue(iwadFiles.Exists(x => x.FileName.Equals("green.wad")));
+            Assert.IsTrue(iwadFiles.Exists(x => x.FileName.Equals("blue.wad")));
+
+            Assert.IsFalse(fileLoadHandler.IsIWadFile(gameProfile));
+            Assert.IsFalse(fileLoadHandler.IsIWadFile(gameFile1));
+            Assert.IsFalse(fileLoadHandler.IsIWadFile(wrongGameFile));
+            Assert.IsTrue(fileLoadHandler.IsIWadFile(gameFile2));
+            Assert.IsTrue(fileLoadHandler.IsIWadFile(gameFile3));
         }
 
-        private static void CreateSourcePort(IDataSourceAdapter adapter, string name, string addfiles)
-        {
-            SourcePortData sourcePort = new SourcePortData
-            {
-                Executable = name,
-                Name = name,
-                Directory = new LauncherPath("SourcePorts"),
-                SupportedExtensions = ".wad",
-                FileOption = "-file",
-                SettingsFiles = addfiles
-            };
 
-            adapter.InsertSourcePort(sourcePort);
+        [TestMethod]
+        public void GetIWadFiles_ReturnsFilesIndirectlyAssociatedWithTheIWad()
+        {
+            // if the iwad has a file attached to it because of a source port, that file should not be included when the iwad is selected
+            // e.g. GZDoom has noendgame.wad User launched DOOM2.WAD with GZDoom. This adds noendgame to the additional files of DOOM2.WAD.
+            // if the user selects DOOM2.WAD with another file (and not GZDoom as the port), noendgame.wad should not be added
+
+
+            var iwadGameFile = InsertIWadAndGameFile("DOOM2.zip", 
+                settingsFiles: "rightfile.zip;ignoreme1.zip", 
+                settingsFilesSourcePort: "ignoreme1.zip"); // Should cancel out the same file in SettingsFiles
+
+            var gameProfile = new GameFile
+            {
+                FileName = "profile.wad",
+                SettingsFilesIWAD = "ignoreme2.wad", // Should get ignored because there is an IWadID
+                IWadID = iwadGameFile.IWadID
+
+            };
+            database.InsertGameFile(gameProfile);
+
+            var gameFile1 = new GameFile // Not used to find the IWAD additional files
+            {
+                FileName = "whoCares.wad",
+                SettingsFilesIWAD = "ignoreme3.wad",
+                IWadID = iwadGameFile.IWadID
+
+            };
+            database.InsertGameFile(gameFile1);
+
+            var rightFile = new GameFile { FileName = "rightfile.zip" };
+            database.InsertGameFile(rightFile);
+
+            var ignoreFile1 = new GameFile { FileName = "ignoreme1.zip" };
+            database.InsertGameFile(ignoreFile1);
+
+            var ignoreFile2 = new GameFile { FileName = "ignoreme2.zip" };
+            database.InsertGameFile(ignoreFile2);
+
+            var ignoreFile3 = new GameFile { FileName = "ignoreme3.zip" };
+            database.InsertGameFile(ignoreFile3);
+
+
+            var fileLoadHandler = new FileLoadHandler(database, gameFile1, gameProfile);
+            var iwadFiles = fileLoadHandler.GetIWadFiles();
+            Assert.AreEqual(1, iwadFiles.Count);
+            Assert.AreEqual("rightfile.zip", iwadFiles.First().FileName);
+            Assert.IsTrue(fileLoadHandler.IsIWadFile(rightFile));
+            Assert.IsFalse(fileLoadHandler.IsIWadFile(gameFile1));
+            Assert.IsFalse(fileLoadHandler.IsIWadFile(ignoreFile1));
+            Assert.IsFalse(fileLoadHandler.IsIWadFile(ignoreFile2));
+            Assert.IsFalse(fileLoadHandler.IsIWadFile(ignoreFile3));
+            Assert.IsFalse(fileLoadHandler.IsIWadFile(iwadGameFile));
+        }
+
+        [TestMethod]
+        public void GetSourcePortFiles_ReturnsFilesAssociatedWithTheSourcePort()
+        {
+            var gameProfile = new GameFile
+            {
+                FileName = "blah.wad",
+                SettingsFilesSourcePort = "a.wad;b.wad"
+            };
+            database.InsertGameFile(gameProfile);
+
+            var gameFile1 = new GameFile { FileName = "ignore me.wad" };
+            database.InsertGameFile(gameFile1);
+
+            var gameFile2 = new GameFile { FileName = "a.wad" };
+            database.InsertGameFile(gameFile2);
+
+            var gameFile3 = new GameFile { FileName = "b.wad" };
+            database.InsertGameFile(gameFile3);
+
+            var fileLoadHandler = new FileLoadHandler(database, gameFile1, gameProfile);
+            var sourcePortFiles = fileLoadHandler.GetSourcePortFiles();
+            Assert.AreEqual(2, sourcePortFiles.Count);
+            Assert.IsTrue(sourcePortFiles.Exists(x => x.FileName.Equals("a.wad")));
+            Assert.IsTrue(sourcePortFiles.Exists(x => x.FileName.Equals("b.wad")));
+            Assert.IsFalse(fileLoadHandler.IsSourcePortFile(gameFile1));
+            Assert.IsFalse(fileLoadHandler.IsSourcePortFile(gameProfile));
+            Assert.IsTrue(fileLoadHandler.IsSourcePortFile(gameFile2));
+            Assert.IsTrue(fileLoadHandler.IsSourcePortFile(gameFile3));
+        }
+
+        [TestMethod]
+        public void GetCurrentAdditionalFiles_ReturnsAssociatedFiles()
+        {
+            var gameProfile = new GameFile
+            {
+                FileName = "PROFILE.wad",
+                SettingsFiles = "first.wad;second.wad"
+            };
+            database.InsertGameFile(gameProfile);
+
+            var gameFile1 = new GameFile 
+            { 
+                FileName = "myhouse.wad",
+                SettingsFiles = "nope.wad;nah.wad" // These should be ignored
+            };
+            database.InsertGameFile(gameFile1);
+
+            var gameFile2 = new GameFile { FileName = "first.wad" };
+            database.InsertGameFile(gameFile2);
+
+            var gameFile3 = new GameFile { FileName = "second.wad" };
+            database.InsertGameFile(gameFile3);
+
+            var wrongGameFile = new GameFile { FileName = "random.wad" };
+            database.InsertGameFile(wrongGameFile);
+
+            var fileLoadHandler = new FileLoadHandler(database, gameFile1, gameProfile);
+            var currentAdditionalFiles = fileLoadHandler.GetCurrentAdditionalFiles();
+
+            Assert.AreEqual(3, currentAdditionalFiles.Count());
+            Assert.IsTrue(currentAdditionalFiles.Exists(x => x.FileName.Equals("myhouse.wad")));
+            Assert.IsTrue(currentAdditionalFiles.Exists(x => x.FileName.Equals("first.wad")));
+            Assert.IsTrue(currentAdditionalFiles.Exists(x => x.FileName.Equals("second.wad")));
+        }
+
+        [TestMethod]
+        public void CalculateAdditionalFiles_IfNoIWadThenClearIWadAndSourcePortFiles()
+        {
+            var gameProfile = new GameFile
+            {
+                FileName = "the_profile.wad",
+                SettingsFilesSourcePort = "sauce_port.zip",
+                SettingsFilesIWAD = "eye_wad.zip"
+            };
+            database.InsertGameFile(gameProfile);
+
+            var gameFile1 = new GameFile { FileName = "file IGNORE.wad" };
+            database.InsertGameFile(gameFile1);
+
+            var gameFile2 = new GameFile { FileName = "sauce_port IGNORE.wad" };
+            database.InsertGameFile(gameFile2);
+
+            var gameFile3 = new GameFile { FileName = "eye_wad IGNORE.wad" };
+            database.InsertGameFile(gameFile3);
+
+            var fileLoadHandler = new FileLoadHandler(database, gameFile1, gameProfile);
+            fileLoadHandler.CalculateAdditionalFiles(null, null);
+
+            Assert.AreEqual(0, fileLoadHandler.GetIWadFiles().Count);
+            Assert.AreEqual(0, fileLoadHandler.GetSourcePortFiles().Count);
+        }
+
+        [TestMethod]
+        public void CalculateAdditionalFiles_IfIWadIsGameFileThenIgnoreIWadAdditionalFiles()
+        {
+            // This was a bug, for an iwad like DOOM2 Doom Launcher sets the SettingsFile to DOOM2.WAD if the user loaded it.
+            // We need to exclude this when using DOOM2 as the iwad for another file
+
+            var gameProfile = new GameFile { FileName = "game-profiley.wad" };
+            database.InsertGameFile(gameProfile);
+
+            var iwadGameFile = InsertIWadAndGameFile("iwad.zip",
+                settingsFiles: "chooseme.zip;ignoreme.zip",
+                settingsFilesSourcePort: "ignoreme.zip"); // Should cancel out the same file in SettingsFiles
+
+            var gameFile1 = new GameFile { FileName = "chooseme.zip" };
+            database.InsertGameFile(gameFile1);
+
+            var gameFile2 = new GameFile { FileName = "ignoreme.zip" };
+            database.InsertGameFile(gameFile2);
+
+            var gameFile3 = new GameFile { FileName = "secondone.zip" };
+            database.InsertGameFile(gameFile3);
+
+            var sourcePort1 = new SourcePortData { Name = "Floom", SettingsFiles = "secondone.zip" };
+            database.InsertSourcePort(sourcePort1);
+
+            var fileLoadHandler = new FileLoadHandler(database, iwadGameFile, gameProfile);
+
+            fileLoadHandler.CalculateAdditionalFiles(iwadGameFile, sourcePort1);
+
+            Assert.AreEqual(0, fileLoadHandler.GetIWadFiles().Count);
+
+            Assert.AreEqual(1, fileLoadHandler.GetSourcePortFiles().Count);
+            Assert.AreEqual("secondone.zip", fileLoadHandler.GetSourcePortFiles().First().FileName);
+        }
+
+        [TestMethod]
+        public void CalculateAdditionalFiles_IfIWadIsNotGameFileThenTakeIWadAdditionalFiles()
+        {
+            var gameProfile = new GameFile { FileName = "game-profilex.wad" };
+            database.InsertGameFile(gameProfile);
+
+            var iwadGameFile = InsertIWadAndGameFile("iwady.zip",
+                settingsFiles: "choosemee.zip;ignoremee.zip",
+                settingsFilesSourcePort: "ignoremee.zip"); // Should cancel out the same file in SettingsFiles
+
+            var theGameFile = new GameFile { FileName = "the-game-file.zip" };
+            database.InsertGameFile(theGameFile);
+
+            var gameFile1 = new GameFile { FileName = "choosemee.zip" };
+            database.InsertGameFile(gameFile1);
+
+            var gameFile2 = new GameFile { FileName = "ignoremee.zip" };
+            database.InsertGameFile(gameFile2);
+
+            var gameFile3 = new GameFile { FileName = "2nd-one.zip" };
+            database.InsertGameFile(gameFile3);
+
+            var sourcePort1 = new SourcePortData { Name = "Broom", SettingsFiles = "2nd-one.zip" };
+            database.InsertSourcePort(sourcePort1);
+
+            var fileLoadHandler = new FileLoadHandler(database, theGameFile, gameProfile);
+
+            fileLoadHandler.CalculateAdditionalFiles(iwadGameFile, sourcePort1);
+
+            Assert.AreEqual(1, fileLoadHandler.GetIWadFiles().Count);
+            Assert.AreEqual("choosemee.zip", fileLoadHandler.GetIWadFiles().First().FileName);
+
+            Assert.AreEqual(1, fileLoadHandler.GetSourcePortFiles().Count);
+            Assert.AreEqual("2nd-one.zip", fileLoadHandler.GetSourcePortFiles().First().FileName);
+        }
+
+        [TestMethod]
+        public void CalculateAdditionalFiles_CorrectlyExcludesThePreviousResults()
+        {
+            // Set up first calculation
+            var gameProfile = new GameFile { FileName = "the-game-profile.wad" };
+            database.InsertGameFile(gameProfile);
+
+            var theGameFile = new GameFile { FileName = "GAME_FILE.zip" };
+            database.InsertGameFile(theGameFile);
+
+            var iwadGameFile1 = InsertIWadAndGameFile("IWAD1.zip",
+                settingsFiles: "right1.zip;right2.zip;wrong1.zip",
+                settingsFilesSourcePort: "wrong1.zip"); // Should cancel out the same file in SettingsFiles
+
+            var sourcePort1 = new SourcePortData { Name = "Broom", SettingsFiles = "sp_right3.zip" };
+            database.InsertSourcePort(sourcePort1);
+
+            var gameFile1 = new GameFile { FileName = "right1.zip" };
+            database.InsertGameFile(gameFile1);
+
+            var gameFile2 = new GameFile { FileName = "right2.zip" };
+            database.InsertGameFile(gameFile2);
+
+            var gameFile3 = new GameFile { FileName = "sp_right3.zip" };
+            database.InsertGameFile(gameFile3);
+
+            var gameFile4 = new GameFile { FileName = "wrong1.zip" };
+            database.InsertGameFile(gameFile4);
+
+            var fileLoadHandler = new FileLoadHandler(database, theGameFile, gameProfile);
+
+            // First calculation
+            fileLoadHandler.CalculateAdditionalFiles(iwadGameFile1, sourcePort1);
+
+            // Additional files includes the game file, plus the added ones
+            var additionalFiles1 = fileLoadHandler.GetCurrentAdditionalFiles();
+            Assert.AreEqual(4, additionalFiles1.Count);
+            Assert.IsTrue(additionalFiles1.Exists(x => x.FileName.Equals("GAME_FILE.zip"))); 
+            Assert.IsTrue(additionalFiles1.Exists(x => x.FileName.Equals("right1.zip")));
+            Assert.IsTrue(additionalFiles1.Exists(x => x.FileName.Equals("right2.zip")));
+            Assert.IsTrue(additionalFiles1.Exists(x => x.FileName.Equals("sp_right3.zip")));
+
+            // They are all new except the game file, which was already there since creation
+            var newAdditionalFiles1 = fileLoadHandler.GetCurrentAdditionalNewFiles();
+            Assert.AreEqual(3, newAdditionalFiles1.Count);
+            Assert.IsTrue(newAdditionalFiles1.Exists(x => x.FileName.Equals("right1.zip")));
+            Assert.IsTrue(newAdditionalFiles1.Exists(x => x.FileName.Equals("right2.zip")));
+            Assert.IsTrue(newAdditionalFiles1.Exists(x => x.FileName.Equals("sp_right3.zip")));
+
+            // Set up second calculation
+            var iwadGameFile2 = InsertIWadAndGameFile("IWAD2.zip",
+                settingsFiles: "right1.zip;NEWRIGHT.ZIP;wrong1.zip", // NEWRIGHT.ZIP instead of right2.zip
+                settingsFilesSourcePort: "wrong1.zip"); // Should cancel out the same file in SettingsFiles
+
+            var sourcePort2 = new SourcePortData { Name = "Vroom", SettingsFiles = "sp_right3.zip" }; // Same as the other one
+            database.InsertSourcePort(sourcePort2);
+
+            var gameFile5 = new GameFile { FileName = "NEWRIGHT.ZIP" };
+            database.InsertGameFile(gameFile5);
+
+            // Second calculation
+            fileLoadHandler.CalculateAdditionalFiles(iwadGameFile2, sourcePort2);
+
+            // Now has NEWRIGHT.ZIP instead of right2.zip
+            var additionalFiles2 = fileLoadHandler.GetCurrentAdditionalFiles();
+            Assert.AreEqual(4, additionalFiles2.Count);
+            Assert.IsTrue(additionalFiles2.Exists(x => x.FileName.Equals("GAME_FILE.zip")));
+            Assert.IsTrue(additionalFiles2.Exists(x => x.FileName.Equals("right1.zip")));
+            Assert.IsTrue(additionalFiles2.Exists(x => x.FileName.Equals("NEWRIGHT.ZIP")));
+            Assert.IsTrue(additionalFiles2.Exists(x => x.FileName.Equals("sp_right3.zip")));
+
+            // Only NEWRIGHT.ZIP is new now
+            var newAdditionalFiles2 = fileLoadHandler.GetCurrentAdditionalNewFiles();
+            Assert.AreEqual(1, newAdditionalFiles2.Count);
+            Assert.AreEqual("NEWRIGHT.ZIP", newAdditionalFiles2.First().FileName); // Only this one is new since the first calculation
+        }
+
+        [TestMethod]
+        public void CalculateAdditionalFiles_AdditionalFilesAreOrderedByIWadFilesThenByEarliest()
+        {
+            // Set up first calculation
+            var gameProfile = new GameFile
+            {
+                FileName = "GAME_PROFILE.wad",
+                SettingsFiles = "og_yes1.zip;og_yes2.zip"
+            };
+            database.InsertGameFile(gameProfile);
+
+            var theGameFile = new GameFile { FileName = "THE_GAME_FILE.zip" };
+            database.InsertGameFile(theGameFile);
+
+            var gameFile1 = new GameFile { FileName = "og_yes1.zip" };
+            database.InsertGameFile(gameFile1);
+
+            var gameFile2 = new GameFile { FileName = "og_yes2.zip" };
+            database.InsertGameFile(gameFile2);
+
+            var fileLoadHandler = new FileLoadHandler(database, theGameFile, gameProfile);
+
+            // First calculation
+            fileLoadHandler.CalculateAdditionalFiles(null, null);
+            Assert.AreEqual(3, fileLoadHandler.GetCurrentAdditionalFiles().Count());
+
+            // Set up second calculation
+            var iwadGameFile1 = InsertIWadAndGameFile("IWAD1.zip",
+                settingsFiles: "iw_yes3.zip;iw_yes4.zip",
+                settingsFilesSourcePort: "");
+
+            var sourcePort1 = new SourcePortData { Name = "GLoom", SettingsFiles = "sp_yes5.zip;sp_yes6.zip" };
+            database.InsertSourcePort(sourcePort1);
+
+            var gameFile3 = new GameFile { FileName = "iw_yes3.zip" };
+            database.InsertGameFile(gameFile3);
+
+            var gameFile4 = new GameFile { FileName = "iw_yes4.zip" };
+            database.InsertGameFile(gameFile4);
+
+            var gameFile5 = new GameFile { FileName = "sp_yes5.zip" };
+            database.InsertGameFile(gameFile5);
+
+            var gameFile6 = new GameFile { FileName = "sp_yes6.zip" };
+            database.InsertGameFile(gameFile6);
+
+            // Second calculation
+            fileLoadHandler.CalculateAdditionalFiles(iwadGameFile1, sourcePort1);
+
+            var additionalFiles1 = fileLoadHandler.GetCurrentAdditionalFiles();
+            Assert.AreEqual(7, additionalFiles1.Count());
+
+            // IWad files are first
+            Assert.AreEqual("iw_yes3.zip", additionalFiles1[0].FileName);
+            Assert.AreEqual("iw_yes4.zip", additionalFiles1[1].FileName);
+
+            // The GameFile was the first original file
+            Assert.AreEqual("THE_GAME_FILE.zip", additionalFiles1[2].FileName);
+
+            // Files from the first calculation are next
+            Assert.AreEqual("og_yes1.zip", additionalFiles1[3].FileName);
+            Assert.AreEqual("og_yes2.zip", additionalFiles1[4].FileName);
+
+            // Then the rest
+            Assert.AreEqual("sp_yes5.zip", additionalFiles1[5].FileName);
+            Assert.AreEqual("sp_yes6.zip", additionalFiles1[6].FileName);
+        }
+
+        [TestMethod]
+        public void Reset_RestoresAdditionalFilesToCreationState()
+        {
+            // Set up creation state
+            var gameProfile = new GameFile
+            {
+                FileName = "the-game-profile.wad",
+                SettingsFiles = "file1.zip;file2.zip"
+            };
+            database.InsertGameFile(gameProfile);
+
+            var theGameFile = new GameFile { FileName = "the-game-file.zip" };
+            database.InsertGameFile(theGameFile);
+
+            var gameFile1 = new GameFile { FileName = "file1.zip" };
+            database.InsertGameFile(gameFile1);
+
+            var gameFile2 = new GameFile { FileName = "file2.zip" };
+            database.InsertGameFile(gameFile2);
+
+            var fileLoadHandler = new FileLoadHandler(database, theGameFile, gameProfile);
+            Assert.AreEqual(3, fileLoadHandler.GetCurrentAdditionalFiles().Count);
+
+            // Set up new state
+            var iwadGameFile1 = InsertIWadAndGameFile("the-iwad.zip",
+                settingsFiles: "new1.zip;new2.zip",
+                settingsFilesSourcePort: "");
+
+            var gameFile3 = new GameFile { FileName = "new1.zip" };
+            database.InsertGameFile(gameFile3);
+
+            var gameFile4 = new GameFile { FileName = "new2.zip" };
+            database.InsertGameFile(gameFile4);
+
+            fileLoadHandler.CalculateAdditionalFiles(iwadGameFile1, null);
+            Assert.AreEqual(5, fileLoadHandler.GetCurrentAdditionalFiles().Count);
+
+            // Reset original state
+            fileLoadHandler.Reset();
+            var additionalFiles = fileLoadHandler.GetCurrentAdditionalFiles();
+            Assert.AreEqual(3, additionalFiles.Count());
+            Assert.IsTrue(additionalFiles.Exists(x => x.FileName.Equals("the-game-file.zip")));
+            Assert.IsTrue(additionalFiles.Exists(x => x.FileName.Equals("file1.zip")));
+            Assert.IsTrue(additionalFiles.Exists(x => x.FileName.Equals("file2.zip")));
+        }
+
+        private IGameFile InsertIWadAndGameFile(String fileName, String settingsFiles, String settingsFilesSourcePort)
+        {
+            IGameFile iwadGameFile = new GameFile
+            {
+                FileName = fileName,
+                SettingsFiles = settingsFiles,
+                SettingsFilesSourcePort = settingsFilesSourcePort
+            };
+            database.InsertGameFile(iwadGameFile);
+            iwadGameFile = database.GetGameFile(fileName);
+
+            IIWadData iwad1 = new IWadData
+            {
+                Name = fileName,
+                GameFileID = iwadGameFile.GameFileID
+            };
+            database.InsertIWad(iwad1);
+            iwad1 = database.GetIWad((int)iwadGameFile.GameFileID);
+            iwadGameFile.IWadID = iwad1.IWadID;
+            database.UpdateGameFile(iwadGameFile);
+
+            return iwadGameFile;
         }
     }
 }

--- a/UnitTest/Tests/TestUtil.cs
+++ b/UnitTest/Tests/TestUtil.cs
@@ -20,8 +20,13 @@ namespace UnitTest.Tests
         {
             var dbAdapter = (DbDataSourceAdapter)adapter;
             var access = new DataAccess(dbAdapter.DbAdapter, dbAdapter.ConnectionString);
+            access.ExecuteNonQuery("delete from Files");
             access.ExecuteNonQuery("delete from GameProfiles");
             access.ExecuteNonQuery("delete from GameFiles");
+            access.ExecuteNonQuery("delete from IWads");
+            access.ExecuteNonQuery("delete from SourcePorts");
+            access.ExecuteNonQuery("delete from TagMapping");
+            access.ExecuteNonQuery("delete from Tags");
         }
 
         public static bool AllFieldsEqualIgnore<T>(T obj1, T obj2, params string[] ignore)

--- a/UnitTest/Tests/TestUtil.cs
+++ b/UnitTest/Tests/TestUtil.cs
@@ -18,15 +18,9 @@ namespace UnitTest.Tests
 
         public static void CleanDatabase(IDataSourceAdapter adapter)
         {
-            var dbAdapter = (DbDataSourceAdapter)adapter;
-            var access = new DataAccess(dbAdapter.DbAdapter, dbAdapter.ConnectionString);
-            access.ExecuteNonQuery("delete from Files");
-            access.ExecuteNonQuery("delete from GameProfiles");
-            access.ExecuteNonQuery("delete from GameFiles");
-            access.ExecuteNonQuery("delete from IWads");
-            access.ExecuteNonQuery("delete from SourcePorts");
-            access.ExecuteNonQuery("delete from TagMapping");
-            access.ExecuteNonQuery("delete from Tags");
+            var dataAccess = ((DbDataSourceAdapter)adapter).DataAccess;
+            dataAccess.ExecuteNonQuery("delete from GameProfiles");
+            dataAccess.ExecuteNonQuery("delete from GameFiles");
         }
 
         public static bool AllFieldsEqualIgnore<T>(T obj1, T obj2, params string[] ignore)

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Tests\TestArchives.cs" />
     <Compile Include="Tests\TestDirectoryArchive.cs" />
     <Compile Include="Tests\TestFileDetector.cs" />
+    <Compile Include="Tests\TestIWad.cs" />
     <Compile Include="Tests\TestGameFile.cs" />
     <Compile Include="Tests\TestGameProfileUtil.cs" />
     <Compile Include="Tests\TestIdGamesFileParser.cs" />

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Tests\TestArchives.cs" />
     <Compile Include="Tests\TestDirectoryArchive.cs" />
     <Compile Include="Tests\TestFileDetector.cs" />
+    <Compile Include="Tests\TestGameFileTags.cs" />
     <Compile Include="Tests\TestIWad.cs" />
     <Compile Include="Tests\TestGameFile.cs" />
     <Compile Include="Tests\TestGameProfileUtil.cs" />


### PR DESCRIPTION
Alrighty! That was a piece of work. 

- TestFile has been rewritten to have isolated Initialize and Cleanup, where the database table is cleared after each one
- Removed code which was specifying primary keys for inserted records, which works the first time, but Sqlite will ignore it and pick a different ID if you try to enter the same record again later. This is confusing behaviour and isn't realistic prod behaviour anyway. The TestUtil.EqualsIgnore method comes in handy here.
- Removed the iterating insertions, which is wasteful and wasn't exposing meaningful cases. 
- Using minimal bespoke fixtures, which apart from being mildly fun, allow a tight focus on corner cases, reduce the chance of false positives from inbred test data, and make debugging really easy.
- Extracted TestIWad from TestGameFile and rewrote it in the same way
- Changed DbDataSourceAdapter to expose DataAccess publicly, and hide ConnectionString and DatabaseAdapter, which is a solid encapsulation win and simplifies cleanup code & TestInit.
- Rewrote TestGameFile and TestLoadFiles in the same way
- Fixed latent bug: parameters were swapped in `DbDataSourceAdapter.UpdateGameFiles`
- Fixed latent bug: accessing member variable instead of method argument in `FileLoadHandler.GetIWadFilesFromGameFile`
