### PR TITLE
Auto load Sigil II from Doom I + II

### DIFF
--- a/DoomLauncher/GameStores/StoreGame.cs
+++ b/DoomLauncher/GameStores/StoreGame.cs
@@ -7,7 +7,8 @@ namespace DoomLauncher.GameStores
         public readonly static StoreGame ULTIMATE_DOOM = new StoreGame(2280, 1317223010, "DOOM + DOOM II", 
             new List<string> { @"rerelease\doom.wad", @"rerelease\doom2.wad", @"rerelease\plutonia.wad", @"rerelease\tnt.wad", 
                                @"base\doom.wad", @"base\doom2\doom2.wad", @"base\plutonia\plutonia.wad", @"base\tnt\tnt.wad" }, 
-            new List<string> { @"rerelease\id1.wad", @"rerelease\nerve.wad", @"rerelease\masterlevels.wad", @"rerelease\sigil.wad" },
+            new List<string> { @"rerelease\id1.wad", @"rerelease\nerve.wad", @"rerelease\masterlevels.wad", @"rerelease\sigil.wad", 
+                               @"rerelease\sigil2.wad" },
             null);
 
         public readonly static StoreGame DOOM2 = new StoreGame(2300, null, "DOOM II", 


### PR DESCRIPTION
The Doom I + II rerelease now comes with Sigil 2 out of the box, which means we can auto load it.