### PR TITLE
Improved sync

### DIFF
--- a/DoomLauncher/Adapters/DbDataSourceAdapter.cs
+++ b/DoomLauncher/Adapters/DbDataSourceAdapter.cs
@@ -228,7 +228,7 @@ namespace DoomLauncher
                     SettingsSpecificFiles = @SettingsSpecificFiles, SettingsStat = @SettingsStat, SettingsLoadLatestSave = @SettingsLoadLatestSave, 
                     FileName = @FileName, MapCount = @MapCount, 
                     MinutesPlayed = @MinutesPlayed, SettingsGameProfileID = @SettingsGameProfileID, SettingsSaved = @SettingsSaved,
-                    SettingsExtraParamsOnly = @SettingsExtraParamsOnly
+                    SettingsExtraParamsOnly = @SettingsExtraParamsOnly, IntendedGame = @IntendedGame, IsSyncNeeded = @IsSyncNeeded
                     where GameFileID = @gameFileID");
             }
 
@@ -247,7 +247,6 @@ namespace DoomLauncher
                 DataAccess.DbAdapter.CreateParameter("GameFileID", gameFile.GameFileID.Value),
                 DataAccess.DbAdapter.CreateParameter("LastPlayed", gameFile.LastPlayed.HasValue ? gameFile.LastPlayed : (object)DBNull.Value),
                 DataAccess.DbAdapter.CreateParameter("Downloaded", gameFile.Downloaded.HasValue ? gameFile.Downloaded : (object)DBNull.Value),
-
                 DataAccess.DbAdapter.CreateParameter("SettingsMap", gameFile.SettingsMap ?? (object)DBNull.Value),
                 DataAccess.DbAdapter.CreateParameter("SettingsSkill", gameFile.SettingsSkill ?? (object)DBNull.Value),
                 DataAccess.DbAdapter.CreateParameter("SettingsExtraParams", gameFile.SettingsExtraParams ?? (object)DBNull.Value),
@@ -265,7 +264,9 @@ namespace DoomLauncher
 
                 DataAccess.DbAdapter.CreateParameter("MinutesPlayed", gameFile.MinutesPlayed),
 
-                DataAccess.DbAdapter.CreateParameter("FileName", gameFile.FileName)
+                DataAccess.DbAdapter.CreateParameter("FileName", gameFile.FileName),
+                DataAccess.DbAdapter.CreateParameter("IntendedGame", gameFile.IntendedGame?.GameName ?? (object)DBNull.Value),
+                DataAccess.DbAdapter.CreateParameter("IsSyncNeeded", gameFile.IsSyncNeeded)
             };
 
             if (m_outOfDateDatabase)

--- a/DoomLauncher/Config/AppVersion.cs
+++ b/DoomLauncher/Config/AppVersion.cs
@@ -41,5 +41,6 @@
         Version_3_7_0_Update1,
         Version_3_7_4,
         Version_3_7_7,
+        Version_3_7_8,
     }
 }

--- a/DoomLauncher/Controls/GameFileTileViewControl.cs
+++ b/DoomLauncher/Controls/GameFileTileViewControl.cs
@@ -10,6 +10,7 @@ namespace DoomLauncher
 {
     public partial class GameFileTileViewControl : UserControl, IGameFileView, IGameFileSortableView
     {
+        public event GameFilesHandler DisplayingGameFiles;
         public event EventHandler ItemClick;
         public event EventHandler ItemDoubleClick;
         public event EventHandler SelectionChange;
@@ -482,6 +483,7 @@ namespace DoomLauncher
             {
                 m_selectedTiles.ForEach(x => x.SetSelected(true));
             }
+            DisplayingGameFiles?.Invoke(gameFiles);
         }
 
         private void SetLayout(List<IGameFile> gameFiles, IEnumerable<IFileData> screenshots, IEnumerable<IFileData> thumbnails)

--- a/DoomLauncher/Controls/GameFileViewControl.cs
+++ b/DoomLauncher/Controls/GameFileViewControl.cs
@@ -13,6 +13,7 @@ namespace DoomLauncher
 {
     public partial class GameFileViewControl : UserControl, IGameFileColumnView
     {
+        public event GameFilesHandler DisplayingGameFiles;
         public event EventHandler ItemClick;
         public event EventHandler ItemDoubleClick;
         public event EventHandler SelectionChange;
@@ -51,7 +52,10 @@ namespace DoomLauncher
 
         public void SetVisible(bool set)
         {
-            // Not required
+            if (set && m_datasource != null)
+            {
+                DisplayingGameFiles?.Invoke((List<IGameFile>)m_datasource.DataSource);
+            }
         }
 
         public bool MultiSelect

--- a/DoomLauncher/DataSources/GameFile.cs
+++ b/DoomLauncher/DataSources/GameFile.cs
@@ -62,7 +62,7 @@ namespace DoomLauncher.DataSources
         public int MinutesPlayed { get; set; }
         public virtual int FileSizeBytes { get; set; }
 
-        public bool IsDoom64 => IWadInfo.DOOM64.Equals(IntendedGame);
+        public bool IsDoom64 => IWadInfo.Doom64.Equals(IntendedGame);
 
         public IWadInfo IntendedGame { get; set; }
 

--- a/DoomLauncher/DataSources/GameFile.cs
+++ b/DoomLauncher/DataSources/GameFile.cs
@@ -2,6 +2,7 @@
 using DoomLauncher.Interfaces;
 using System;
 using System.IO;
+using System.Web;
 
 namespace DoomLauncher.DataSources
 {
@@ -61,7 +62,11 @@ namespace DoomLauncher.DataSources
         public int MinutesPlayed { get; set; }
         public virtual int FileSizeBytes { get; set; }
 
-        public bool IsDoom64 { get; set; }
+        public bool IsDoom64 => IWadInfo.DOOM64.Equals(IntendedGame);
+
+        public IWadInfo IntendedGame { get; set; }
+
+        public bool IsSyncNeeded { get; set; }
 
         public bool IsUnmanaged() => IsUnmanaged(FileName);
 

--- a/DoomLauncher/DoomLauncher.csproj
+++ b/DoomLauncher/DoomLauncher.csproj
@@ -277,6 +277,7 @@
     <Compile Include="Handlers\Sync\Doom64TitlePicSyncAction.cs" />
     <Compile Include="Handlers\Sync\GameConfSyncAction.cs" />
     <Compile Include="Handlers\Sync\GameInfoSyncAction.cs" />
+    <Compile Include="Handlers\Sync\IntendedIwadSyncAction.cs" />
     <Compile Include="Handlers\Sync\ISyncAction.cs" />
     <Compile Include="Handlers\Sync\IWadTitlesSyncAction.cs" />
     <Compile Include="Handlers\Sync\KnownWadsSyncAction.cs" />

--- a/DoomLauncher/Forms/MainForm.cs
+++ b/DoomLauncher/Forms/MainForm.cs
@@ -1525,7 +1525,7 @@ namespace DoomLauncher
 
             foreach (string file in files)
             {
-                IWadInfo info = IWadInfo.GetIWadInfo(file);
+                IWadInfo info = IWadInfo.FromFileName(file);
 
                 if (type == AddFileType.GameFile && info != null)
                     warnFiles.Add(Path.GetFileName(file));
@@ -2566,6 +2566,9 @@ namespace DoomLauncher
                 UseWaitCursor = true;
                 if (!m_progressBars.TryGetValue(type, out var progressBar))
                     return null;
+
+                if (progressBar.Visible)
+                    return progressBar; // Already shown, just return
 
                 progressBar.StartPosition = FormStartPosition.CenterParent;
                 progressBar.Show(this);

--- a/DoomLauncher/Forms/MainForm_Init.cs
+++ b/DoomLauncher/Forms/MainForm_Init.cs
@@ -53,7 +53,22 @@ namespace DoomLauncher
             tabViews.AddRange(CreateTagTabs(GameFileViewFactory.DefaultColumnTextFields, colConfig));
 
             m_tabHandler = new TabHandler(tabControl);
+            m_tabHandler.DisplayingGameFiles += TabHandler_DisplayingGameFiles;
             m_tabHandler.SetTabs(tabViews);
+            
+        }
+
+        private void TabHandler_DisplayingGameFiles(List<IGameFile> gameFiles)
+        {
+            var gameFilesThatNeedSync = gameFiles
+                .Where(f => f.IsSyncNeeded)
+                .Select(f => f.FileName)
+                .ToArray();
+
+            if (gameFilesThatNeedSync.Count() > 0)
+            {
+                _ = SyncLocalDatabase(gameFilesThatNeedSync, AppConfiguration.FileManagement, true);
+            }
         }
 
         private void SetShowTabHeaders()
@@ -668,7 +683,9 @@ namespace DoomLauncher
                     GameFileFieldType.Rating,
                     GameFileFieldType.MapCount,
                     GameFileFieldType.MinutesPlayed,
-                    GameFileFieldType.IWadID
+                    GameFileFieldType.IWadID,
+                    GameFileFieldType.IntendedGame,
+                    GameFileFieldType.IsSyncNeeded
                 };
             }
         }

--- a/DoomLauncher/Forms/MainForm_Meta.cs
+++ b/DoomLauncher/Forms/MainForm_Meta.cs
@@ -33,8 +33,8 @@ namespace DoomLauncher
             {
                 if (iwads.Contains(localFile.GameFileID.Value))
                 {
-                    IWadInfo info = IWadInfo.GetIWadInfo(localFile.FileNameNoPath);
-                    if (info != null && !info.HasMetadata)
+                    IWadInfo info = IWadInfo.FromFileName(localFile.FileNameNoPath);
+                    if (info != null)
                     {
                         iwadWarn.Add(localFile.FileNameNoPath);
                         continue;

--- a/DoomLauncher/Forms/MainForm_Play.cs
+++ b/DoomLauncher/Forms/MainForm_Play.cs
@@ -2,6 +2,7 @@
 using DoomLauncher.Adapters.Launch;
 using DoomLauncher.DataSources;
 using DoomLauncher.Forms;
+using DoomLauncher.Handlers.Sync;
 using DoomLauncher.Interfaces;
 using DoomLauncher.SourcePort;
 using DoomLauncher.Stylize;
@@ -74,6 +75,8 @@ namespace DoomLauncher
             if (launchData.GameFile == null)
                 return;
 
+            ConfirmIWad(launchData.GameFile);
+
             SetupPlayForm(launchData.GameFile);
             if (sourcePort != null) 
                 m_currentPlayForm.SelectedSourcePort = sourcePort;
@@ -106,6 +109,24 @@ namespace DoomLauncher
             else
             {
                 HandleSelectionChange(GetCurrentViewControl(), true);
+            }
+        }
+
+        private void ConfirmIWad(IGameFile gameFile)
+        {
+            // This method works. But the real solution is for the "Delete IWad" function
+            // to properly clean up the dead references in the database.
+
+            var iwadId = gameFile.IWadID;
+
+            // Could be a bogus ID if the IWAD was deleted
+            var actualIWad = DataSourceAdapter.GetIWads().FirstOrDefault(x => x.IWadID == gameFile.IWadID);
+
+            if (actualIWad == null)
+            {
+                gameFile.IWadID = null;
+                new IntendedIwadSyncAction(DataSourceAdapter).ApplyIntendedGame(gameFile);
+                DataSourceAdapter.UpdateGameFile(gameFile, new GameFileFieldType[] { GameFileFieldType.IWadID });
             }
         }
 

--- a/DoomLauncher/Forms/MainForm_Sync.cs
+++ b/DoomLauncher/Forms/MainForm_Sync.cs
@@ -13,14 +13,30 @@ namespace DoomLauncher
 {
     public partial class MainForm
     {
+        private readonly System.Threading.SemaphoreSlim _syncSemaphore = new System.Threading.SemaphoreSlim(1, 1);
+
         private async Task<SyncResult> SyncLocalDatabase(string[] fileNames, FileManagement fileManagement, bool updateViews, ITagData tag = null)
         {
-            var pg = ProgressBarStart(ProgressBarType.Sync);
-            pg.Text = $"Syncing {fileNames.Count()} files...";
-            SyncResult syncResult =  await Task.Run(() => ExecuteSyncHandler(fileNames, fileManagement, tag));
-            ProgressBarEnd(ProgressBarType.Sync);
-            SyncLocalDatabaseComplete(syncResult, updateViews);
-            return syncResult;
+            // Try to enter the semaphore without waiting
+            if (!await _syncSemaphore.WaitAsync(0))
+            {
+                // Another sync is already running, ignore this request
+                return SyncResult.EMPTY;
+            }
+
+            try
+            {
+                var pg = ProgressBarStart(ProgressBarType.Sync);
+                pg.Text = $"Syncing {fileNames.Count()} files...";
+                SyncResult syncResult = await Task.Run(() => ExecuteSyncHandler(fileNames, fileManagement, tag));
+                ProgressBarEnd(ProgressBarType.Sync);
+                SyncLocalDatabaseComplete(syncResult, updateViews);
+                return syncResult;
+            }
+            finally
+            {
+                _syncSemaphore.Release();
+            }
         }
 
         void SyncLocalDatabaseComplete(SyncResult syncResult, bool updateViews)
@@ -96,14 +112,15 @@ namespace DoomLauncher
                     new MapStringSyncAction(AppConfiguration.TempDirectory),
                     new GameInfoSyncAction(),
                     new StartupImageSyncAction(),
-                    new TitlePicSyncAction(DataSourceAdapter, 
+                    new TitlePicSyncAction(DataSourceAdapter,
                                             DataCache.Instance.DefaultPalette,
                                             DataCache.Instance.HexenPalette,
                                             DataCache.Instance.HereticPalette).OnlyIf(AppConfiguration.AutomaticallyPullTitlpic),
                     new Doom64TitlePicSyncAction(),
                     new IWadTitlesSyncAction(),
-                    new GameConfSyncAction(DataSourceAdapter),
-                    new KnownWadsSyncAction(DataSourceAdapter)
+                    new KnownWadsSyncAction(DataSourceAdapter),
+                    new GameConfSyncAction(),
+                    new IntendedIwadSyncAction(DataSourceAdapter)
                 };
 
                 handler = new SyncLibraryHandler(DataSourceAdapter, DirectoryDataSourceAdapter, AppConfiguration, 
@@ -233,7 +250,7 @@ namespace DoomLauncher
                 DataSourceAdapter.InsertIWad(new IWadData() { GameFileID = gameFile.GameFileID.Value, FileName = gameFile.FileName, Name = gameFile.FileName });
                 var iwad = DataSourceAdapter.GetIWads().OrderBy(x => x.IWadID).LastOrDefault();
 
-                IWadInfo wadInfo = IWadInfo.GetIWadInfo(gameFile.FileName);
+                IWadInfo wadInfo = IWadInfo.FromFileName(gameFile.FileName);
                 gameFile.Title = wadInfo == null ? Path.GetFileNameWithoutExtension(gameFile.FileName).ToUpper() : wadInfo.Title;
                 DataSourceAdapter.UpdateGameFile(gameFile, new GameFileFieldType[] { GameFileFieldType.Title });
 

--- a/DoomLauncher/Handlers/Sync/Doom64SyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/Doom64SyncAction.cs
@@ -19,7 +19,7 @@ namespace DoomLauncher.Handlers.Sync {
 
             if (isDoom64)
             {
-                file.IntendedGame = IWadInfo.DOOM64;
+                file.IntendedGame = IWadInfo.Doom64;
                 var doom64Iwad = m_database.GetGameFile("doom64.zip");
                 if (doom64Iwad != null)
                 {

--- a/DoomLauncher/Handlers/Sync/Doom64SyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/Doom64SyncAction.cs
@@ -16,10 +16,10 @@ namespace DoomLauncher.Handlers.Sync {
         public SyncResult ApplyToGameFile(IGameFile file, IArchiveReader reader, string[] mapInfoData)
         {
             var isDoom64 = IsDoom64Wad(mapInfoData);
-            file.IsDoom64 = isDoom64;
 
             if (isDoom64)
             {
+                file.IntendedGame = IWadInfo.DOOM64;
                 var doom64Iwad = m_database.GetGameFile("doom64.zip");
                 if (doom64Iwad != null)
                 {

--- a/DoomLauncher/Handlers/Sync/GameConfSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/GameConfSyncAction.cs
@@ -10,13 +10,6 @@ namespace DoomLauncher.Handlers.Sync
 {
     public class GameConfSyncAction : ISyncAction
     {
-        private readonly IDataSourceAdapter m_database;
-
-        public GameConfSyncAction(IDataSourceAdapter database)
-        {
-            m_database = database;
-        }
-
         public SyncResult ApplyToGameFile(IGameFile gameFile, IArchiveReader reader, string[] mapInfoData)
         {
             var entry = reader.Entries.FirstOrDefault(e => e.Name.ToLower().Equals("gameconf"));
@@ -46,11 +39,11 @@ namespace DoomLauncher.Handlers.Sync
 
                     if (!string.IsNullOrEmpty(iwad))
                     {
-                        var gameName = Path.GetFileNameWithoutExtension(iwad.ToLower());
-                        var iwadFile = m_database.GetIWads().FirstOrDefault(x =>
-                            Path.GetFileNameWithoutExtension(x.Name.ToLower()).Equals(gameName));
-                        if (iwadFile != null)
-                            gameFile.IWadID = iwadFile.IWadID;
+                        IWadInfo iwadInfo = IWadInfo.FromFileName(iwad);
+                        if (iwadInfo != null)
+                        {
+                            gameFile.IntendedGame = iwadInfo;
+                        }
                     }
                 }
                 catch

--- a/DoomLauncher/Handlers/Sync/GameInfoSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/GameInfoSyncAction.cs
@@ -1,4 +1,6 @@
 ﻿using DoomLauncher.Interfaces;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -10,9 +12,6 @@ namespace DoomLauncher.Handlers.Sync
     /// </summary>
     public class GameInfoSyncAction : ISyncAction
     {
-        private static readonly Regex STARTUPTITLE_REGEX = new Regex(@"\s*STARTUPTITLE\s*=\s*"".*"""); //@"\s*{0}\s*:[^=]*";
-        private static readonly Regex SUBTRACT_REGEX = new Regex(@"\s*STARTUPTITLE\s*=\s*");
-
         public SyncResult ApplyToGameFile(IGameFile gameFile, IArchiveReader reader, string[] mapInfoData)
         {
             // Normally it's GAMEINFO, but I've seen GAMEINFO.txt in the wild. 
@@ -20,21 +19,47 @@ namespace DoomLauncher.Handlers.Sync
             if (entry != null)
             {
                 var text = entry.ReadString(Encoding.UTF7);
-                Match m = STARTUPTITLE_REGEX.Match(text);
-                if (m.Success)
+                var mapping = ParseGameInfo(text);
+
+                if (mapping.TryGetValue("STARTUPTITLE", out var title) && !string.IsNullOrWhiteSpace(title))
                 {
-                    var fullStatement = m.Value;
-                    var assignment = SUBTRACT_REGEX.Match(fullStatement);
-                    if (assignment.Success)
+                    gameFile.Title = title;
+                }
+
+                if (mapping.TryGetValue("IWAD", out var iwad) && !string.IsNullOrEmpty(iwad))
+                {
+                    IWadInfo iwadInfo = IWadInfo.FromFileName(iwad);
+                    if (iwadInfo != null)
                     {
-                        var title = fullStatement.Substring(assignment.Length + 1, fullStatement.Length - assignment.Length - 2).Trim();
-                        if (!string.IsNullOrEmpty(title))
-                            gameFile.Title = title;
+                        gameFile.IntendedGame = iwadInfo;
                     }
                 }
             }
 
             return SyncResult.EMPTY;
+        }
+
+        private Dictionary<string, string> ParseGameInfo(string gameInfo)
+        {
+            string[] lines = gameInfo.Split(new char[] { '\n' }, System.StringSplitOptions.RemoveEmptyEntries);
+
+            Dictionary<string, string> mapping = new Dictionary<string, string>();
+            foreach (var line in lines)
+            {
+                string[] keyValues = line.Split('=');
+                if (keyValues.Length >= 2)
+                {
+                    string key = keyValues[0].Trim();
+                    string value = keyValues.Skip(1).Aggregate("", (a, b) => a + b).Trim();
+
+                    // This won't work for comma-separated values, as expected for LOAD and STARTUPCOLORS,
+                    // but we don't care about those for the time being.
+                    if (value[0] == '\"' && value[value.Length-1] == '\"')
+                        value = value.Substring(1, value.Length - 2);
+                    mapping[key] = value;
+                }
+            }
+            return mapping;
         }
     }
 }

--- a/DoomLauncher/Handlers/Sync/ISyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/ISyncAction.cs
@@ -4,7 +4,7 @@ namespace DoomLauncher.Handlers.Sync
 {
     public interface ISyncAction
     {
-        SyncResult ApplyToGameFile(IGameFile file, IArchiveReader reader, string[] mapInfoData);
+        SyncResult ApplyToGameFile(IGameFile gameFile, IArchiveReader reader, string[] mapInfoData);
     }
 
     class EmptySyncAction : ISyncAction

--- a/DoomLauncher/Handlers/Sync/IWadTitlesSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/IWadTitlesSyncAction.cs
@@ -11,7 +11,7 @@ namespace DoomLauncher.Handlers.Sync
     {
         public SyncResult ApplyToGameFile(IGameFile gameFile, IArchiveReader reader, string[] mapInfoData)
         {
-            IWadInfo info = IWadInfo.GetIWadInfo(gameFile.FileName);
+            IWadInfo info = IWadInfo.FromFileName(gameFile.FileName);
             if (info != null)
                 gameFile.Title = info.Title;
 

--- a/DoomLauncher/Handlers/Sync/IdGamesTextFileParser.cs
+++ b/DoomLauncher/Handlers/Sync/IdGamesTextFileParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace DoomLauncher.Handlers.Sync
@@ -25,7 +26,15 @@ namespace DoomLauncher.Handlers.Sync
             var description = FindValue(text, "Description", s_fullRegexDescription, false).Replace("\r\n", "\n");
             var game = FindValue(text, "Game", s_fullRegex, false);
 
-            return new IdGamesTextInfo(title, author, releaseDate, description, game);
+            return new IdGamesTextInfo(title, author, releaseDate, description, GetGameString(game));
+        }
+
+        private static string GetGameString(string rawString)
+        {
+            var sb = new StringBuilder(rawString);
+            sb.Replace(" ", "");
+            sb.Replace("II", "2");
+            return sb.ToString().Trim().ToUpper();
         }
 
         private DateTime? ParseReleaseDate(string text)

--- a/DoomLauncher/Handlers/Sync/IdGamesTextInfo.cs
+++ b/DoomLauncher/Handlers/Sync/IdGamesTextInfo.cs
@@ -15,7 +15,6 @@ namespace DoomLauncher.Handlers.Sync
             ReleaseDate = releaseDate;
             Description = description ?? "";
             Game = game ?? "";
-
         }
 
         public int QualityScore 
@@ -54,5 +53,4 @@ namespace DoomLauncher.Handlers.Sync
         public override int GetHashCode() => 
             (Title, Author, ReleaseDate, Description, Game).GetHashCode();
     }
-
 }

--- a/DoomLauncher/Handlers/Sync/IntendedIwadSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/IntendedIwadSyncAction.cs
@@ -1,0 +1,41 @@
+﻿using DoomLauncher.DataSources;
+using DoomLauncher.Interfaces;
+using System.Linq;
+
+namespace DoomLauncher.Handlers.Sync
+{
+    public class IntendedIwadSyncAction : ISyncAction
+    {
+        private readonly IIWadDataSourceAdapter m_database;
+
+        public IntendedIwadSyncAction(IIWadDataSourceAdapter database)
+        {
+            m_database = database;
+        }
+
+        public void ApplyIntendedGame(IGameFile gameFile)
+        {
+            if (gameFile.IntendedGame != null)
+            {
+                var iwadsFromDb = m_database.GetIWads();
+                var matchingIWad = iwadsFromDb.FirstOrDefault(iwad => iwad.FileName == gameFile.IntendedGame?.FileName);
+
+                if (matchingIWad == null && gameFile.IntendedGame?.BackupGame != null)
+                {
+                    // If the intended game is not found, try the backup game
+                    matchingIWad = iwadsFromDb.FirstOrDefault(iwad => iwad.FileName == gameFile.IntendedGame.BackupGame.FileName);
+                }
+                if (matchingIWad != null)
+                {
+                    gameFile.IWadID = matchingIWad.IWadID;
+                }
+            }
+        }
+
+        public SyncResult ApplyToGameFile(IGameFile gameFile, IArchiveReader reader, string[] mapInfoData)
+        {
+            ApplyIntendedGame(gameFile);
+            return SyncResult.EMPTY;
+        }
+    }
+}

--- a/DoomLauncher/Handlers/Sync/MapInfoUtil.cs
+++ b/DoomLauncher/Handlers/Sync/MapInfoUtil.cs
@@ -22,7 +22,7 @@ namespace DoomLauncher.Handlers.Sync
             {
                 try
                 {
-                    data[i] = Encoding.UTF8.GetString(entries[i].ReadEntry());
+                    data[i] = entries[i].ReadString(Encoding.UTF8);
                 }
                 catch
                 {

--- a/DoomLauncher/Handlers/Sync/MapStringSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/MapStringSyncAction.cs
@@ -124,7 +124,7 @@ namespace DoomLauncher.Handlers.Sync
             {
                 try
                 {
-                    data[i] = Encoding.UTF8.GetString(entries[i].ReadEntry());
+                    data[i] = entries[i].ReadString(Encoding.UTF8);
                 }
                 catch
                 {

--- a/DoomLauncher/Handlers/Sync/TextFileSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/TextFileSyncAction.cs
@@ -58,11 +58,11 @@ namespace DoomLauncher.Handlers.Sync
         {
             string name = gameName.ToUpper();
             if (name == "ULTIMATEDOOM")
-                return IWadInfo.DOOM;
+                return IWadInfo.Doom;
             else if (gameName.StartsWith("DOOM64"))
-                return IWadInfo.DOOM64;
+                return IWadInfo.Doom64;
             else if (gameName.StartsWith("DOOM2"))
-                return IWadInfo.DOOM2;
+                return IWadInfo.Doom2;
             else
                 return IWadInfo.FromGameName(gameName);
         }

--- a/DoomLauncher/Handlers/Sync/TextFileSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/TextFileSyncAction.cs
@@ -38,6 +38,9 @@ namespace DoomLauncher.Handlers.Sync
             if (!string.IsNullOrEmpty(bestInfo.Description))
                 gameFile.Description = bestInfo.Description;
 
+            if (!string.IsNullOrEmpty(bestInfo.Game))
+                gameFile.IntendedGame = SelectGame(bestInfo.Game);
+
             if (string.IsNullOrWhiteSpace(gameFile.Title))
                 gameFile.Title = GetUserFriendlyFilename(gameFile.FileNameNoPath);
 
@@ -49,6 +52,19 @@ namespace DoomLauncher.Handlers.Sync
             var words = Path.GetFileNameWithoutExtension(filename).Replace("_", " ").Replace("-", " ").Split();
             var capitalisedWords = words.Select(word => string.Concat(word[0].ToString().ToUpper(), word.Substring(1)));
             return string.Join(" ", capitalisedWords.ToArray());
+        }
+
+        private static IWadInfo SelectGame(string gameName)
+        {
+            string name = gameName.ToUpper();
+            if (name == "ULTIMATEDOOM")
+                return IWadInfo.DOOM;
+            else if (gameName.StartsWith("DOOM64"))
+                return IWadInfo.DOOM64;
+            else if (gameName.StartsWith("DOOM2"))
+                return IWadInfo.DOOM2;
+            else
+                return IWadInfo.FromGameName(gameName);
         }
 
         private bool isTxtFile(string filename)

--- a/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
@@ -39,7 +39,7 @@ namespace DoomLauncher.Handlers.Sync
             {
                 if (TitlePicUtil.GetEntry(reader, HereticHexenTitlepicName, out entry))
                 {
-                    if (IWadInfo.HEXEN.Equals(file.IntendedGame) || "hexen".Equals(GetIWadFileNameBase(file.IWadID), StringComparison.OrdinalIgnoreCase))
+                    if (IWadInfo.Hexen.Equals(file.IntendedGame) || "hexen".Equals(GetIWadFileNameBase(file.IWadID), StringComparison.OrdinalIgnoreCase))
                         palette = m_hexenPalette;
                     else
                         palette = m_hereticPalette;

--- a/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
@@ -41,7 +41,7 @@ namespace DoomLauncher.Handlers.Sync
                 {
                     var iwadFileName = m_database.GetIWads().FirstOrDefault(iw => iw.IWadID == file.IWadID)?.FileNameBase;
 
-                    if (iwadFileName != null && iwadFileName.Equals("hexen", StringComparison.OrdinalIgnoreCase))
+                    if (file.IntendedGame.Equals(IWadInfo.HEXEN) || iwadFileName != null && iwadFileName.Equals("hexen", StringComparison.OrdinalIgnoreCase))
                         palette = m_hexenPalette;
                     else
                         palette = m_hereticPalette;
@@ -81,15 +81,13 @@ namespace DoomLauncher.Handlers.Sync
 
         private Palette GetPaletteOrDefault(IGameFile gameFile, IArchiveReader reader)
         {
-            if (!TitlePicUtil.FindPalette(reader, out IArchiveEntry paletteEntry))
+            if (TitlePicUtil.FindPalette(reader, out IArchiveEntry paletteEntry))
             {
-                return m_doomPalette;
+                Palette palette = Palette.From(paletteEntry.ReadEntry());
+                if (palette != null)
+                    return palette;
             }
-
-            Palette palette = Palette.From(paletteEntry.ReadEntry());
-            if (palette != null)
-                return palette;
-
+            
             return m_doomPalette;
         }
     }

--- a/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
@@ -39,9 +39,7 @@ namespace DoomLauncher.Handlers.Sync
             {
                 if (TitlePicUtil.GetEntry(reader, HereticHexenTitlepicName, out entry))
                 {
-                    var iwadFileName = m_database.GetIWads().FirstOrDefault(iw => iw.IWadID == file.IWadID)?.FileNameBase;
-
-                    if (file.IntendedGame.Equals(IWadInfo.HEXEN) || iwadFileName != null && iwadFileName.Equals("hexen", StringComparison.OrdinalIgnoreCase))
+                    if (IWadInfo.HEXEN.Equals(file.IntendedGame) || "hexen".Equals(GetIWadFileNameBase(file.IWadID), StringComparison.OrdinalIgnoreCase))
                         palette = m_hexenPalette;
                     else
                         palette = m_hereticPalette;
@@ -61,6 +59,9 @@ namespace DoomLauncher.Handlers.Sync
 
             return SyncResult.TitlePic(file, image);
         }
+
+        private string GetIWadFileNameBase(int? iwadID) =>
+            m_database.GetIWads().FirstOrDefault(iw => iw.IWadID == iwadID)?.FileNameBase;
 
         private bool GetTitlepicNameFromMapInfo(string[] mapInfoData, out string newTitlepicName)
         {

--- a/DoomLauncher/Handlers/SyncLibraryHandler.cs
+++ b/DoomLauncher/Handlers/SyncLibraryHandler.cs
@@ -80,6 +80,8 @@ namespace DoomLauncher
                 resultSoFar += SyncResult.InvalidFile(fileName, errorMsg);
             }
 
+            fileToUpdate.IsSyncNeeded = false;
+
             resultSoFar += Upsert(existingFile, fileToUpdate);
 
             return resultSoFar;

--- a/DoomLauncher/Handlers/TabHandler.cs
+++ b/DoomLauncher/Handlers/TabHandler.cs
@@ -6,6 +6,8 @@ namespace DoomLauncher
 {
     class TabHandler
     {
+        public event GameFilesHandler DisplayingGameFiles;
+
         private readonly Dictionary<IGameFileView, TabItem> m_tabLookup = new Dictionary<IGameFileView, TabItem>();
         private readonly List<ITabView> m_tabs = new List<ITabView>();
 
@@ -16,7 +18,7 @@ namespace DoomLauncher
         }
 
         public TabHandler(CTabControl tabControl)
-        {            
+        {
             TabControl = tabControl;
         }
 
@@ -44,11 +46,12 @@ namespace DoomLauncher
 
         public void AddTab(ITabView tab)
         {
+
             TabPage page = CreateTabPage(tab);
 
             m_tabLookup.Add(tab.GameFileViewControl, new TabItem { TabView = tab, TabPage = page });
             m_tabs.Add(tab);
-
+            SubscribeToTabEvents(tab);
             TabControl.TabPages.Add(page);
         }
 
@@ -59,6 +62,18 @@ namespace DoomLauncher
 
             m_tabLookup.Add(tab.GameFileViewControl, new TabItem { TabView = tab, TabPage = page });
             m_tabs.Insert(index, tab);
+            SubscribeToTabEvents(tab);
+        }
+
+        private static bool IsTabUpdatable(ITabView tabView) =>
+            !tabView.Key.Equals("Id Games");
+
+        private void SubscribeToTabEvents(ITabView tab)
+        {
+            if (IsTabUpdatable(tab))
+            {
+                tab.GameFileViewControl.DisplayingGameFiles += (gameFiles) => DisplayingGameFiles?.Invoke(gameFiles);
+            }
         }
 
         public void RemoveTab(ITabView tab)

--- a/DoomLauncher/Handlers/Util.cs
+++ b/DoomLauncher/Handlers/Util.cs
@@ -65,6 +65,11 @@ namespace DoomLauncher
                     convertedObj = true;
                 return true;
             }
+            else if (obj.GetType() == typeof(string) && t == typeof(IWadInfo) && IWadInfo.IsGameName(obj))
+            {
+                convertedObj = IWadInfo.FromGameName(obj);
+                return true;
+            }
             else if (t.BaseType == typeof(Enum))
             {
                 convertedObj = Convert.ToInt32(obj);
@@ -337,7 +342,9 @@ namespace DoomLauncher
                     GameFileFieldType.Rating,
                     GameFileFieldType.Map,
                     GameFileFieldType.MapCount,
-                    GameFileFieldType.IWadID
+                    GameFileFieldType.IWadID,
+                    GameFileFieldType.IntendedGame,
+                    GameFileFieldType.IsSyncNeeded
                 };
             }
         }

--- a/DoomLauncher/Handlers/VersionHandler.cs
+++ b/DoomLauncher/Handlers/VersionHandler.cs
@@ -95,6 +95,7 @@ namespace DoomLauncher
                 ExecuteUpdate(Pre_Version_3_7_0_Update1, AppVersion.Version_3_7_0_Update1);
                 ExecuteUpdate(Pre_Version_3_7_4, AppVersion.Version_3_7_4);
                 ExecuteUpdate(Pre_Version_3_7_7, AppVersion.Version_3_7_7);
+                ExecuteUpdate(Pre_Version_3_7_8, AppVersion.Version_3_7_8);
             }
 
             return new VersionUpdateResults(m_restartRequired);
@@ -166,11 +167,11 @@ namespace DoomLauncher
             if (dt.Rows.Count == 0)
             {
                 string query = @"CREATE TABLE 'Configuration' (
-	                'ConfigID'	INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-	                'Name'	TEXT NOT NULL,
-	                'Value'	TEXT NOT NULL,
-	                'AvailableValues'	TEXT NOT NULL,
-	                'UserCanModify'	INTEGER);";
+                    'ConfigID'	INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                    'Name'	TEXT NOT NULL,
+                    'Value'	TEXT NOT NULL,
+                    'AvailableValues'	TEXT NOT NULL,
+                    'UserCanModify'	INTEGER);";
 
                 DataAccess.ExecuteNonQuery(query);
 
@@ -214,15 +215,15 @@ namespace DoomLauncher
             if (dt.Rows.Count == 0)
             {
                 string query = @"CREATE TABLE 'Tags' (
-	            'TagID'	INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-	            'Name'	TEXT NOT NULL,
-	            'HasTab'	INTEGER NOT NULL);";
+                'TagID'	INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                'Name'	TEXT NOT NULL,
+                'HasTab'	INTEGER NOT NULL);";
                 DataAccess.ExecuteSelect(query);
 
                 query = @"CREATE TABLE 'TagMapping' (
-	            'FileID'	INTEGER NOT NULL,
-	            'TagID'	INTEGER NOT NULL,
-	            PRIMARY KEY(FileID,TagID));";
+                'FileID'	INTEGER NOT NULL,
+                'TagID'	INTEGER NOT NULL,
+                PRIMARY KEY(FileID,TagID));";
                 DataAccess.ExecuteSelect(query);
             }
 
@@ -313,8 +314,8 @@ namespace DoomLauncher
                 DataAccess.ExecuteNonQuery("update Configuration set UserCanModify = 1 where Name = 'GameFileDirectory'");
 
                 string query = @"CREATE TABLE 'Stats' (
-	            'StatID'	INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-	            'GameFileID'	INTEGER NOT NULL,
+                'StatID'	INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                'GameFileID'	INTEGER NOT NULL,
                 'KillCount'	INTEGER NOT NULL,
                 'TotalKills'	INTEGER NOT NULL,
                 'SecretCount'	INTEGER NOT NULL,
@@ -500,18 +501,18 @@ namespace DoomLauncher
             if (dt.Rows.Count == 0)
             {
                 string query = @"CREATE TABLE 'GameProfiles' (
-	                    'GameProfileID'	INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                        'GameProfileID'	INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
                         'GameFileID'	INTEGER NOT NULL,
                         'SourcePortID'	INTEGER NOT NULL,
                         'IWadID'	INTEGER NOT NULL,
                         'Name'	TEXT NOT NULL,
-	                    'SettingsMap'	TEXT,
-	                    'SettingsSkill'	TEXT,
-	                    'SettingsExtraParams'	TEXT,
-	                    'SettingsFiles'	TEXT,
-	                    'SettingsFilesSourcePort'	TEXT,
-	                    'SettingsFilesIWAD'	TEXT,
-	                    'SettingsSpecificFiles'	TEXT,
+                        'SettingsMap'	TEXT,
+                        'SettingsSkill'	TEXT,
+                        'SettingsExtraParams'	TEXT,
+                        'SettingsFiles'	TEXT,
+                        'SettingsFilesSourcePort'	TEXT,
+                        'SettingsFilesIWAD'	TEXT,
+                        'SettingsSpecificFiles'	TEXT,
                         'SettingsStat'	INTEGER,
                         'SettingsSaved' INTEGER);";
 
@@ -707,7 +708,7 @@ namespace DoomLauncher
             {
                 string query = @"CREATE TABLE 'CleanupFiles' (
                     'CleanupFileID'	INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-	                'FileName' TEXT NOT NULL);";
+                    'FileName' TEXT NOT NULL);";
 
                 DataAccess.ExecuteNonQuery(query);
             }
@@ -897,6 +898,28 @@ namespace DoomLauncher
             {
                 DataAccess.ExecuteNonQuery("alter table GameFiles add column 'IsDoom64' INTEGER;");
                 DataAccess.ExecuteNonQuery("update GameFiles set IsDoom64 = 0");
+            }
+        }
+
+        private void Pre_Version_3_7_8()
+        {
+            var dt = DataAccess.ExecuteSelect("pragma table_info(GameFiles);").Tables[0];
+
+            if (!dt.Select("name = 'IntendedGame'").Any())
+            {
+                DataAccess.ExecuteNonQuery("alter table GameFiles add column 'IntendedGame' TEXT;");
+                DataAccess.ExecuteNonQuery("update GameFiles set IntendedGame = 'DOOM64' where IsDoom64 = 1;");
+            }
+
+            if (dt.Select("name = 'IsDoom64'").Any())
+            {
+                DataAccess.ExecuteNonQuery("alter table GameFiles drop column 'IsDoom64';");
+            }
+
+            if (!dt.Select("name = 'IsSyncNeeded'").Any())
+            {
+                DataAccess.ExecuteNonQuery("alter table GameFiles add column 'IsSyncNeeded' INTEGER NOT NULL DEFAULT 0;");
+                DataAccess.ExecuteNonQuery("update GameFiles set IsSyncNeeded = 1");
             }
         }
 

--- a/DoomLauncher/IWad/IWadInfo.cs
+++ b/DoomLauncher/IWad/IWadInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 
 namespace DoomLauncher
@@ -25,7 +26,7 @@ namespace DoomLauncher
 
         private static readonly IWadInfo[] ALL = new IWadInfo[]
         {
-            Doom1, Doom,Doom2, Plutonia, TNT, FreeDoom1, FreeDoom2, FreeDM, Chex, 
+            Doom1, Doom,Doom2, Plutonia, TNT, FreeDoom1, FreeDoom2, FreeDM, Chex,
             Chex3, Hacx, Heretic1, Heretic, Hexen, Strife0, Strife1, Doom64
         };
 
@@ -61,7 +62,7 @@ namespace DoomLauncher
         public static IWadInfo FromFileName(string fileName) =>
             FromGameName(GetGameName(fileName));
 
-        private static string GetGameName(string fileName) => 
+        private static string GetGameName(string fileName) =>
             Path.GetFileNameWithoutExtension(fileName).ToUpper();
 
         public override string ToString() =>
@@ -70,7 +71,12 @@ namespace DoomLauncher
         public override int GetHashCode() =>
             GameName.GetHashCode();
 
-        public override bool Equals(object o) => 
-            GameName.Equals((o as IWadInfo)?.GameName);
+        public override bool Equals(object o)
+        {
+            if (!(o is IWadInfo other))
+                return false;
+
+            return string.Equals(GameName, other.GameName, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/DoomLauncher/IWad/IWadInfo.cs
+++ b/DoomLauncher/IWad/IWadInfo.cs
@@ -4,27 +4,51 @@ using System.Linq;
 
 namespace DoomLauncher
 {
+
+
     public class IWadInfo
     {
-        public static readonly IWadInfo FreeDoom1 = new IWadInfo("FREEDOOM1", "Freedoom: Phase 1", string.Empty);
-        public static readonly IWadInfo FreeDoom2 = new IWadInfo("FREEDOOM2", "Freedoom: Phase 2", string.Empty);
-        public static readonly IWadInfo Doom1 = new IWadInfo("DOOM1", "Doom Shareware", "doom.png", Doom);
-        public static readonly IWadInfo Doom = new IWadInfo("DOOM", "The Ultimate Doom", "doom.png", FreeDoom1);
-        public static readonly IWadInfo Doom2 = new IWadInfo("DOOM2", "Doom II: Hell on Earth", "doom2.png", FreeDoom2);
-        public static readonly IWadInfo Plutonia = new IWadInfo("PLUTONIA", "Final Doom: The Plutonia Experiment", "plutonia.png");
-        public static readonly IWadInfo TNT = new IWadInfo("TNT", "Final Doom: TNT: Evilution", "tnt.png");
-        public static readonly IWadInfo FreeDM = new IWadInfo("FREEDM", "FreeDM", string.Empty);
-        public static readonly IWadInfo Chex = new IWadInfo("CHEX", "Chex Quest", "chexquest.png");
-        public static readonly IWadInfo Chex3 = new IWadInfo("CHEX3", "Chex Quest 3", "chexquest3.png");
-        public static readonly IWadInfo Hacx = new IWadInfo("HACX", "Hacx: Twitch 'n Kill", "hacx.png");
-        public static readonly IWadInfo Heretic1 = new IWadInfo("HERETIC1", "Heretic Shareware", "heretic.png", Heretic);
-        public static readonly IWadInfo Heretic = new IWadInfo("HERETIC", "Heretic: Shadow of the Serpent Riders", "heretic.png");
-        public static readonly IWadInfo Hexen = new IWadInfo("HEXEN", "Hexen: Beyond Heretic", "hexen.png");
-        public static readonly IWadInfo Strife0 = new IWadInfo("STRIFE0", "Strife Demo", "strife.png", Strife1);
-        public static readonly IWadInfo Strife1 = new IWadInfo("STRIFE1", "Strife: Quest for the Sigil", "strife.png");
-        public static readonly IWadInfo Doom64 = new IWadInfo("DOOM64", "Doom 64", "doom64.png");
+        private enum IWadType
+        {
+            FreeDoom1,
+            FreeDoom2,
+            Doom1,
+            Doom,
+            Doom2,
+            Plutonia,
+            TNT,
+            FreeDM,
+            Chex,
+            Chex3,
+            Hacx,
+            Heretic1,
+            Heretic,
+            Hexen,
+            Strife0,
+            Strife1,
+            Doom64
+        }
 
-        private static readonly IWadInfo[] ALL = new IWadInfo[]
+        public static readonly IWadInfo FreeDoom1 = new IWadInfo(IWadType.FreeDoom1, "FREEDOOM1", "Freedoom: Phase 1", string.Empty);
+        public static readonly IWadInfo FreeDoom2 = new IWadInfo(IWadType.FreeDoom2, "FREEDOOM2", "Freedoom: Phase 2", string.Empty);
+        public static readonly IWadInfo Doom1 = new IWadInfo(IWadType.Doom1, "DOOM1", "Doom Shareware", "doom.png", Doom);
+        public static readonly IWadInfo Doom = new IWadInfo(IWadType.Doom, "DOOM", "The Ultimate Doom", "doom.png", FreeDoom1);
+        public static readonly IWadInfo Doom2 = new IWadInfo(IWadType.Doom2, "DOOM2", "Doom II: Hell on Earth", "doom2.png", FreeDoom2);
+        public static readonly IWadInfo Plutonia = new IWadInfo(IWadType.Plutonia, "PLUTONIA", "Final Doom: The Plutonia Experiment", "plutonia.png");
+        public static readonly IWadInfo TNT = new IWadInfo(IWadType.TNT, "TNT", "Final Doom: TNT: Evilution", "tnt.png");
+        public static readonly IWadInfo FreeDM = new IWadInfo(IWadType.FreeDM, "FREEDM", "FreeDM", string.Empty);
+        public static readonly IWadInfo Chex = new IWadInfo(IWadType.Chex, "CHEX", "Chex Quest", "chexquest.png");
+        public static readonly IWadInfo Chex3 = new IWadInfo(IWadType.Chex3, "CHEX3", "Chex Quest 3", "chexquest3.png");
+        public static readonly IWadInfo Hacx = new IWadInfo(IWadType.Hacx, "HACX", "Hacx: Twitch 'n Kill", "hacx.png");
+        public static readonly IWadInfo Heretic1 = new IWadInfo(IWadType.Heretic1, "HERETIC1", "Heretic Shareware", "heretic.png", Heretic);
+        public static readonly IWadInfo Heretic = new IWadInfo(IWadType.Heretic, "HERETIC", "Heretic: Shadow of the Serpent Riders", "heretic.png");
+        public static readonly IWadInfo Hexen = new IWadInfo(IWadType.Hexen, "HEXEN", "Hexen: Beyond Heretic", "hexen.png");
+        public static readonly IWadInfo Strife0 = new IWadInfo(IWadType.Strife0, "STRIFE0", "Strife Demo", "strife.png", Strife1);
+        public static readonly IWadInfo Strife1 = new IWadInfo(IWadType.Strife1, "STRIFE1", "Strife: Quest for the Sigil", "strife.png");
+        public static readonly IWadInfo Doom64 = new IWadInfo(IWadType.Doom64, "DOOM64", "Doom 64", "doom64.png");
+
+
+        private static readonly IWadInfo[] All = new IWadInfo[]
         {
             Doom1, Doom,Doom2, Plutonia, TNT, FreeDoom1, FreeDoom2, FreeDM, Chex,
             Chex3, Hacx, Heretic1, Heretic, Hexen, Strife0, Strife1, Doom64
@@ -38,8 +62,11 @@ namespace DoomLauncher
 
         public IWadInfo BackupGame { get; }
 
-        private IWadInfo(string gameName, string title, string tileImage, IWadInfo backupGame = null)
+        private readonly IWadType _iwadType;
+
+        private IWadInfo(IWadType iWadType, string gameName, string title, string tileImage, IWadInfo backupGame = null)
         {
+            _iwadType = iWadType;
             GameName = gameName;
             Title = title;
             TileImage = Path.Combine(LauncherPath.GetDataDirectory(), "TileImages", tileImage);
@@ -54,10 +81,10 @@ namespace DoomLauncher
         }
 
         public static bool IsGameName(string gameName) =>
-            ALL.FirstOrDefault(iwadInfo => iwadInfo.GameName == gameName) != null;
+            All.FirstOrDefault(iwadInfo => iwadInfo.GameName == gameName) != null;
 
         public static IWadInfo FromGameName(string gameName) =>
-            ALL.FirstOrDefault(iwadInfo => iwadInfo.GameName.Equals(gameName));
+            All.FirstOrDefault(iwadInfo => iwadInfo.GameName.Equals(gameName));
 
         public static IWadInfo FromFileName(string fileName) =>
             FromGameName(GetGameName(fileName));
@@ -69,14 +96,14 @@ namespace DoomLauncher
             GameName;
 
         public override int GetHashCode() =>
-            GameName.GetHashCode();
+            _iwadType.GetHashCode();
 
         public override bool Equals(object o)
         {
             if (!(o is IWadInfo other))
                 return false;
 
-            return string.Equals(GameName, other.GameName, StringComparison.OrdinalIgnoreCase);
+            return _iwadType == other._iwadType;
         }
     }
 }

--- a/DoomLauncher/IWad/IWadInfo.cs
+++ b/DoomLauncher/IWad/IWadInfo.cs
@@ -5,28 +5,28 @@ namespace DoomLauncher
 {
     public class IWadInfo
     {
-        public static readonly IWadInfo FREEDOOM1 = new IWadInfo("FREEDOOM1", "Freedoom: Phase 1", string.Empty);
-        public static readonly IWadInfo FREEDOOM2 = new IWadInfo("FREEDOOM2", "Freedoom: Phase 2", string.Empty);
-        public static readonly IWadInfo DOOM1 = new IWadInfo("DOOM1", "Doom Shareware", "doom.png", DOOM);
-        public static readonly IWadInfo DOOM = new IWadInfo("DOOM", "The Ultimate Doom", "doom.png", FREEDOOM1);
-        public static readonly IWadInfo DOOM2 = new IWadInfo("DOOM2", "Doom II: Hell on Earth", "doom2.png", FREEDOOM2);
-        public static readonly IWadInfo PLUTONIA = new IWadInfo("PLUTONIA", "Final Doom: The Plutonia Experiment", "plutonia.png");
+        public static readonly IWadInfo FreeDoom1 = new IWadInfo("FREEDOOM1", "Freedoom: Phase 1", string.Empty);
+        public static readonly IWadInfo FreeDoom2 = new IWadInfo("FREEDOOM2", "Freedoom: Phase 2", string.Empty);
+        public static readonly IWadInfo Doom1 = new IWadInfo("DOOM1", "Doom Shareware", "doom.png", Doom);
+        public static readonly IWadInfo Doom = new IWadInfo("DOOM", "The Ultimate Doom", "doom.png", FreeDoom1);
+        public static readonly IWadInfo Doom2 = new IWadInfo("DOOM2", "Doom II: Hell on Earth", "doom2.png", FreeDoom2);
+        public static readonly IWadInfo Plutonia = new IWadInfo("PLUTONIA", "Final Doom: The Plutonia Experiment", "plutonia.png");
         public static readonly IWadInfo TNT = new IWadInfo("TNT", "Final Doom: TNT: Evilution", "tnt.png");
-        public static readonly IWadInfo FREEDM = new IWadInfo("FREEDM", "FreeDM", string.Empty);
-        public static readonly IWadInfo CHEX = new IWadInfo("CHEX", "Chex Quest", "chexquest.png");
-        public static readonly IWadInfo CHEX3 = new IWadInfo("CHEX3", "Chex Quest 3", "chexquest3.png");
-        public static readonly IWadInfo HACX = new IWadInfo("HACX", "Hacx: Twitch 'n Kill", "hacx.png");
-        public static readonly IWadInfo HERETIC1 = new IWadInfo("HERETIC1", "Heretic Shareware", "heretic.png", HERETIC);
-        public static readonly IWadInfo HERETIC = new IWadInfo("HERETIC", "Heretic: Shadow of the Serpent Riders", "heretic.png");
-        public static readonly IWadInfo HEXEN = new IWadInfo("HEXEN", "Hexen: Beyond Heretic", "hexen.png");
-        public static readonly IWadInfo STRIFE0 = new IWadInfo("STRIFE0", "Strife Demo", "strife.png", STRIFE1);
-        public static readonly IWadInfo STRIFE1 = new IWadInfo("STRIFE1", "Strife: Quest for the Sigil", "strife.png");
-        public static readonly IWadInfo DOOM64 = new IWadInfo("DOOM64", "Doom 64", "doom64.png");
+        public static readonly IWadInfo FreeDM = new IWadInfo("FREEDM", "FreeDM", string.Empty);
+        public static readonly IWadInfo Chex = new IWadInfo("CHEX", "Chex Quest", "chexquest.png");
+        public static readonly IWadInfo Chex3 = new IWadInfo("CHEX3", "Chex Quest 3", "chexquest3.png");
+        public static readonly IWadInfo Hacx = new IWadInfo("HACX", "Hacx: Twitch 'n Kill", "hacx.png");
+        public static readonly IWadInfo Heretic1 = new IWadInfo("HERETIC1", "Heretic Shareware", "heretic.png", Heretic);
+        public static readonly IWadInfo Heretic = new IWadInfo("HERETIC", "Heretic: Shadow of the Serpent Riders", "heretic.png");
+        public static readonly IWadInfo Hexen = new IWadInfo("HEXEN", "Hexen: Beyond Heretic", "hexen.png");
+        public static readonly IWadInfo Strife0 = new IWadInfo("STRIFE0", "Strife Demo", "strife.png", Strife1);
+        public static readonly IWadInfo Strife1 = new IWadInfo("STRIFE1", "Strife: Quest for the Sigil", "strife.png");
+        public static readonly IWadInfo Doom64 = new IWadInfo("DOOM64", "Doom 64", "doom64.png");
 
         private static readonly IWadInfo[] ALL = new IWadInfo[]
         {
-            DOOM1, DOOM,DOOM2, PLUTONIA, TNT, FREEDOOM1, FREEDOOM2, FREEDM, CHEX, 
-            CHEX3, HACX, HERETIC1, HERETIC, HEXEN, STRIFE0, STRIFE1, DOOM64
+            Doom1, Doom,Doom2, Plutonia, TNT, FreeDoom1, FreeDoom2, FreeDM, Chex, 
+            Chex3, Hacx, Heretic1, Heretic, Hexen, Strife0, Strife1, Doom64
         };
 
         public string GameName { get; }

--- a/DoomLauncher/IWad/IWadInfo.cs
+++ b/DoomLauncher/IWad/IWadInfo.cs
@@ -1,71 +1,76 @@
 ﻿using System.IO;
+using System.Linq;
 
 namespace DoomLauncher
 {
-    class IWadInfo
+    public class IWadInfo
     {
+        public static readonly IWadInfo FREEDOOM1 = new IWadInfo("FREEDOOM1", "Freedoom: Phase 1", string.Empty);
+        public static readonly IWadInfo FREEDOOM2 = new IWadInfo("FREEDOOM2", "Freedoom: Phase 2", string.Empty);
+        public static readonly IWadInfo DOOM1 = new IWadInfo("DOOM1", "Doom Shareware", "doom.png", DOOM);
+        public static readonly IWadInfo DOOM = new IWadInfo("DOOM", "The Ultimate Doom", "doom.png", FREEDOOM1);
+        public static readonly IWadInfo DOOM2 = new IWadInfo("DOOM2", "Doom II: Hell on Earth", "doom2.png", FREEDOOM2);
+        public static readonly IWadInfo PLUTONIA = new IWadInfo("PLUTONIA", "Final Doom: The Plutonia Experiment", "plutonia.png");
+        public static readonly IWadInfo TNT = new IWadInfo("TNT", "Final Doom: TNT: Evilution", "tnt.png");
+        public static readonly IWadInfo FREEDM = new IWadInfo("FREEDM", "FreeDM", string.Empty);
+        public static readonly IWadInfo CHEX = new IWadInfo("CHEX", "Chex Quest", "chexquest.png");
+        public static readonly IWadInfo CHEX3 = new IWadInfo("CHEX3", "Chex Quest 3", "chexquest3.png");
+        public static readonly IWadInfo HACX = new IWadInfo("HACX", "Hacx: Twitch 'n Kill", "hacx.png");
+        public static readonly IWadInfo HERETIC1 = new IWadInfo("HERETIC1", "Heretic Shareware", "heretic.png", HERETIC);
+        public static readonly IWadInfo HERETIC = new IWadInfo("HERETIC", "Heretic: Shadow of the Serpent Riders", "heretic.png");
+        public static readonly IWadInfo HEXEN = new IWadInfo("HEXEN", "Hexen: Beyond Heretic", "hexen.png");
+        public static readonly IWadInfo STRIFE0 = new IWadInfo("STRIFE0", "Strife Demo", "strife.png", STRIFE1);
+        public static readonly IWadInfo STRIFE1 = new IWadInfo("STRIFE1", "Strife: Quest for the Sigil", "strife.png");
+        public static readonly IWadInfo DOOM64 = new IWadInfo("DOOM64", "Doom 64", "doom64.png");
+
+        private static readonly IWadInfo[] ALL = new IWadInfo[]
+        {
+            DOOM1, DOOM,DOOM2, PLUTONIA, TNT, FREEDOOM1, FREEDOOM2, FREEDM, CHEX, 
+            CHEX3, HACX, HERETIC1, HERETIC, HEXEN, STRIFE0, STRIFE1, DOOM64
+        };
+
+        public string GameName { get; }
         public string Title { get; }
         public string TileImage { get; }
-        public bool HasMetadata { get; }
 
-        public IWadInfo(string title, string tileImage, bool hasMeta = false)
+        public string FileName { get; }
+
+        public IWadInfo BackupGame { get; }
+
+        private IWadInfo(string gameName, string title, string tileImage, IWadInfo backupGame = null)
         {
+            GameName = gameName;
             Title = title;
             TileImage = Path.Combine(LauncherPath.GetDataDirectory(), "TileImages", tileImage);
-            HasMetadata = hasMeta;
+            FileName = $"{GameName.ToLower()}.zip";
+            BackupGame = backupGame;
         }
 
         public static bool TryGetIWadInfo(string fileName, out IWadInfo iwadInfo)
         {
-            iwadInfo = GetIWadInfo(fileName);
+            iwadInfo = FromFileName(fileName);
             return iwadInfo != null;
         }
 
-        public static IWadInfo GetIWadInfo(string fileName)
-        {
-            string name = Path.GetFileNameWithoutExtension(fileName).ToUpper();
+        public static bool IsGameName(string gameName) =>
+            ALL.FirstOrDefault(iwadInfo => iwadInfo.GameName == gameName) != null;
 
-            switch (name)
-            {
-                case "DOOM1":
-                    return new IWadInfo("Doom Shareware", "doom.png");
-                case "DOOM":
-                    return new IWadInfo("The Ultimate Doom", "doom.png");
-                case "DOOM2":
-                    return new IWadInfo("Doom II: Hell on Earth", "doom2.png");
-                case "PLUTONIA":
-                    return new IWadInfo("Final Doom: The Plutonia Experiment", "plutonia.png");
-                case "TNT":
-                    return new IWadInfo("Final Doom: TNT: Evilution", "tnt.png");
-                case "FREEDOOM1":
-                    return new IWadInfo("Freedoom: Phase 1", string.Empty);
-                case "FREEDOOM2":
-                    return new IWadInfo("Freedoom: Phase 2", string.Empty);
-                case "FREEDM":
-                    return new IWadInfo("FreeDM", string.Empty);
-                case "CHEX":
-                    return new IWadInfo("Chex Quest", "chexquest.png");
-                case "CHEX3":
-                    return new IWadInfo("Chex Quest 3", "chexquest3.png");
-                case "HACX":
-                    return new IWadInfo("Hacx: Twitch 'n Kill", "hacx.png");
-                case "HERETIC1":
-                    return new IWadInfo("Heretic Shareware", "heretic.png");
-                case "HERETIC":
-                    return new IWadInfo("Heretic: Shadow of the Serpent Riders", "heretic.png");
-                case "HEXEN":
-                    return new IWadInfo("Hexen: Beyond Heretic", "hexen.png");
-                case "STRIFE0":
-                    return new IWadInfo("Strife Demo", "strife.png");
-                case "STRIFE1":
-                    return new IWadInfo("Strife: Quest for the Sigil", "strife.png");
-                case "DOOM64":
-                    return new IWadInfo("Doom 64", "doom64.png");
-                default:
-                    break;
-            }
+        public static IWadInfo FromGameName(string gameName) =>
+            ALL.FirstOrDefault(iwadInfo => iwadInfo.GameName.Equals(gameName));
 
-            return null;
-        }  
+        public static IWadInfo FromFileName(string fileName) =>
+            FromGameName(GetGameName(fileName));
+
+        private static string GetGameName(string fileName) => 
+            Path.GetFileNameWithoutExtension(fileName).ToUpper();
+
+        public override string ToString() =>
+            GameName;
+
+        public override int GetHashCode() =>
+            GameName.GetHashCode();
+
+        public override bool Equals(object o) => 
+            GameName.Equals((o as IWadInfo)?.GameName);
     }
 }

--- a/DoomLauncher/IWad/IWadInfo.cs
+++ b/DoomLauncher/IWad/IWadInfo.cs
@@ -4,48 +4,46 @@ using System.Linq;
 
 namespace DoomLauncher
 {
-
+    public enum IWadType
+    {
+        FreeDoom1,
+        FreeDoom2,
+        Doom1,
+        Doom,
+        Doom2,
+        Plutonia,
+        TNT,
+        FreeDM,
+        Chex,
+        Chex3,
+        Hacx,
+        Heretic1,
+        Heretic,
+        Hexen,
+        Strife0,
+        Strife1,
+        Doom64
+    }
 
     public class IWadInfo
     {
-        private enum IWadType
-        {
-            FreeDoom1,
-            FreeDoom2,
-            Doom1,
-            Doom,
-            Doom2,
-            Plutonia,
-            TNT,
-            FreeDM,
-            Chex,
-            Chex3,
-            Hacx,
-            Heretic1,
-            Heretic,
-            Hexen,
-            Strife0,
-            Strife1,
-            Doom64
-        }
-
-        public static readonly IWadInfo FreeDoom1 = new IWadInfo(IWadType.FreeDoom1, "FREEDOOM1", "Freedoom: Phase 1", string.Empty);
-        public static readonly IWadInfo FreeDoom2 = new IWadInfo(IWadType.FreeDoom2, "FREEDOOM2", "Freedoom: Phase 2", string.Empty);
-        public static readonly IWadInfo Doom1 = new IWadInfo(IWadType.Doom1, "DOOM1", "Doom Shareware", "doom.png", Doom);
-        public static readonly IWadInfo Doom = new IWadInfo(IWadType.Doom, "DOOM", "The Ultimate Doom", "doom.png", FreeDoom1);
-        public static readonly IWadInfo Doom2 = new IWadInfo(IWadType.Doom2, "DOOM2", "Doom II: Hell on Earth", "doom2.png", FreeDoom2);
-        public static readonly IWadInfo Plutonia = new IWadInfo(IWadType.Plutonia, "PLUTONIA", "Final Doom: The Plutonia Experiment", "plutonia.png");
-        public static readonly IWadInfo TNT = new IWadInfo(IWadType.TNT, "TNT", "Final Doom: TNT: Evilution", "tnt.png");
-        public static readonly IWadInfo FreeDM = new IWadInfo(IWadType.FreeDM, "FREEDM", "FreeDM", string.Empty);
-        public static readonly IWadInfo Chex = new IWadInfo(IWadType.Chex, "CHEX", "Chex Quest", "chexquest.png");
-        public static readonly IWadInfo Chex3 = new IWadInfo(IWadType.Chex3, "CHEX3", "Chex Quest 3", "chexquest3.png");
-        public static readonly IWadInfo Hacx = new IWadInfo(IWadType.Hacx, "HACX", "Hacx: Twitch 'n Kill", "hacx.png");
-        public static readonly IWadInfo Heretic1 = new IWadInfo(IWadType.Heretic1, "HERETIC1", "Heretic Shareware", "heretic.png", Heretic);
-        public static readonly IWadInfo Heretic = new IWadInfo(IWadType.Heretic, "HERETIC", "Heretic: Shadow of the Serpent Riders", "heretic.png");
-        public static readonly IWadInfo Hexen = new IWadInfo(IWadType.Hexen, "HEXEN", "Hexen: Beyond Heretic", "hexen.png");
-        public static readonly IWadInfo Strife0 = new IWadInfo(IWadType.Strife0, "STRIFE0", "Strife Demo", "strife.png", Strife1);
-        public static readonly IWadInfo Strife1 = new IWadInfo(IWadType.Strife1, "STRIFE1", "Strife: Quest for the Sigil", "strife.png");
-        public static readonly IWadInfo Doom64 = new IWadInfo(IWadType.Doom64, "DOOM64", "Doom 64", "doom64.png");
+        public static readonly IWadInfo FreeDoom1 = new IWadInfo(IWadType.FreeDoom1, "Freedoom: Phase 1", string.Empty);
+        public static readonly IWadInfo FreeDoom2 = new IWadInfo(IWadType.FreeDoom2, "Freedoom: Phase 2", string.Empty);
+        public static readonly IWadInfo Doom1 = new IWadInfo(IWadType.Doom1, "Doom Shareware", "doom.png", Doom);
+        public static readonly IWadInfo Doom = new IWadInfo(IWadType.Doom, "The Ultimate Doom", "doom.png", FreeDoom1);
+        public static readonly IWadInfo Doom2 = new IWadInfo(IWadType.Doom2, "Doom II: Hell on Earth", "doom2.png", FreeDoom2);
+        public static readonly IWadInfo Plutonia = new IWadInfo(IWadType.Plutonia, "Final Doom: The Plutonia Experiment", "plutonia.png");
+        public static readonly IWadInfo TNT = new IWadInfo(IWadType.TNT, "Final Doom: TNT: Evilution", "tnt.png");
+        public static readonly IWadInfo FreeDM = new IWadInfo(IWadType.FreeDM, "FreeDM", string.Empty);
+        public static readonly IWadInfo Chex = new IWadInfo(IWadType.Chex, "Chex Quest", "chexquest.png");
+        public static readonly IWadInfo Chex3 = new IWadInfo(IWadType.Chex3, "Chex Quest 3", "chexquest3.png");
+        public static readonly IWadInfo Hacx = new IWadInfo(IWadType.Hacx, "Hacx: Twitch 'n Kill", "hacx.png");
+        public static readonly IWadInfo Heretic1 = new IWadInfo(IWadType.Heretic1, "Heretic Shareware", "heretic.png", Heretic);
+        public static readonly IWadInfo Heretic = new IWadInfo(IWadType.Heretic, "Heretic: Shadow of the Serpent Riders", "heretic.png");
+        public static readonly IWadInfo Hexen = new IWadInfo(IWadType.Hexen, "Hexen: Beyond Heretic", "hexen.png");
+        public static readonly IWadInfo Strife0 = new IWadInfo(IWadType.Strife0, "Strife Demo", "strife.png", Strife1);
+        public static readonly IWadInfo Strife1 = new IWadInfo(IWadType.Strife1, "Strife: Quest for the Sigil", "strife.png");
+        public static readonly IWadInfo Doom64 = new IWadInfo(IWadType.Doom64, "Doom 64", "doom64.png");
 
 
         private static readonly IWadInfo[] All = new IWadInfo[]
@@ -54,7 +52,10 @@ namespace DoomLauncher
             Chex3, Hacx, Heretic1, Heretic, Hexen, Strife0, Strife1, Doom64
         };
 
-        public string GameName { get; }
+        public IWadType IWadType { get; }
+
+        public string GameName => IWadType.ToString().ToUpper();
+
         public string Title { get; }
         public string TileImage { get; }
 
@@ -62,12 +63,9 @@ namespace DoomLauncher
 
         public IWadInfo BackupGame { get; }
 
-        private readonly IWadType _iwadType;
-
-        private IWadInfo(IWadType iWadType, string gameName, string title, string tileImage, IWadInfo backupGame = null)
+        private IWadInfo(IWadType iWadType, string title, string tileImage, IWadInfo backupGame = null)
         {
-            _iwadType = iWadType;
-            GameName = gameName;
+            IWadType = iWadType;
             Title = title;
             TileImage = Path.Combine(LauncherPath.GetDataDirectory(), "TileImages", tileImage);
             FileName = $"{GameName.ToLower()}.zip";
@@ -96,14 +94,14 @@ namespace DoomLauncher
             GameName;
 
         public override int GetHashCode() =>
-            _iwadType.GetHashCode();
+            IWadType.GetHashCode();
 
         public override bool Equals(object o)
         {
             if (!(o is IWadInfo other))
                 return false;
 
-            return _iwadType == other._iwadType;
+            return IWadType == other.IWadType;
         }
     }
 }

--- a/DoomLauncher/Interfaces/IGameFile.cs
+++ b/DoomLauncher/Interfaces/IGameFile.cs
@@ -39,7 +39,11 @@ namespace DoomLauncher.Interfaces
         int MinutesPlayed { get; set; }
         int FileSizeBytes { get; set; }
 
-        bool IsDoom64 { get; set; }
+        bool IsDoom64 { get; }
+
+        IWadInfo IntendedGame { get; set; }
+
+        bool IsSyncNeeded { get; set; }
 
         bool IsUnmanaged();
         bool IsDirectory();

--- a/DoomLauncher/Interfaces/IGameFileView.cs
+++ b/DoomLauncher/Interfaces/IGameFileView.cs
@@ -15,9 +15,11 @@ namespace DoomLauncher
     }
 
     public delegate void GameFileEventHandler(object sender, GameFileEventArgs e);
+    public delegate void GameFilesHandler(List<IGameFile> gameFiles);
 
     public interface IGameFileView
     {
+        event GameFilesHandler DisplayingGameFiles;
         event EventHandler ItemClick;
         event EventHandler ItemDoubleClick;
         event EventHandler SelectionChange;

--- a/DoomLauncher/SaveGame/HelionSaveGameReader.cs
+++ b/DoomLauncher/SaveGame/HelionSaveGameReader.cs
@@ -40,7 +40,7 @@ namespace DoomLauncher.SaveGame
             if (entry == null)
                 return null;
 
-            JObject data = JsonConvert.DeserializeObject(Encoding.UTF8.GetString(entry.ReadEntry())) as JObject;
+            JObject data = JsonConvert.DeserializeObject(entry.ReadString(Encoding.UTF8)) as JObject;
             JToken textData = data.GetValue("Text");
             if (textData == null)
                 return null;

--- a/DoomLauncher/Search/GameFileFieldType.cs
+++ b/DoomLauncher/Search/GameFileFieldType.cs
@@ -29,6 +29,8 @@
         SettingsGameProfileID,
         SettingsSaved,
         SettingsLoadLatestSave,
-        SettingsExtraParamsOnly
+        SettingsExtraParamsOnly,
+        IntendedGame,
+        IsSyncNeeded
     }
 }

--- a/UnitTest/Tests/Helpers/TreeEntry.cs
+++ b/UnitTest/Tests/Helpers/TreeEntry.cs
@@ -1,6 +1,7 @@
 ﻿using DoomLauncher;
 using System;
 using System.Linq;
+using System.Text;
 
 namespace UnitTest.Tests
 {

--- a/UnitTest/Tests/TestDoom64SyncAction.cs
+++ b/UnitTest/Tests/TestDoom64SyncAction.cs
@@ -80,7 +80,7 @@ namespace UnitTest.Tests
 
             syncAction.ApplyToGameFile(file, null, mapInfoData);
 
-            Assert.AreEqual(IWadInfo.DOOM64, file.IntendedGame);
+            Assert.AreEqual(IWadInfo.Doom64, file.IntendedGame);
         }
     }
 }

--- a/UnitTest/Tests/TestDoom64SyncAction.cs
+++ b/UnitTest/Tests/TestDoom64SyncAction.cs
@@ -70,5 +70,17 @@ namespace UnitTest.Tests
             Assert.IsFalse(result.Failed);
             Assert.AreEqual(666, file.IWadID);
         }
+
+        [TestMethod]
+        public void ApplyToGameFile_SetsIntendedGameToDoom64()
+        {
+            var syncAction = new Doom64SyncAction(database);
+            GameFile file = new GameFile { GameFileID = 1 };
+            var mapInfoData = new string[] { "classtype = something" };
+
+            syncAction.ApplyToGameFile(file, null, mapInfoData);
+
+            Assert.AreEqual(IWadInfo.DOOM64, file.IntendedGame);
+        }
     }
 }

--- a/UnitTest/Tests/TestGameConfSyncAction.cs
+++ b/UnitTest/Tests/TestGameConfSyncAction.cs
@@ -10,20 +10,6 @@ namespace UnitTest.Tests
     [TestClass]
     public class TestGameConfSyncAction
     {
-        private DbDataSourceAdapter database;
-
-        [TestInitialize]
-        public void Initialize()
-        {
-            database = (DbDataSourceAdapter)TestUtil.CreateAdapter();
-        }
-
-        [TestCleanup]
-        public void Cleanup()
-        {
-            database.DataAccess.ExecuteNonQuery("delete from IWads");
-        }
-
         [TestMethod]
         public void ApplyToGameFile_SetsTitle()
         {
@@ -36,7 +22,7 @@ namespace UnitTest.Tests
             Tree files = new Tree("root", new Tree("GAMECONF", 
                 "{\"data\": { \"title\": \"Bingo Bongo\" }} "));
             var reader = new TreeReader(files);
-            var action = new GameConfSyncAction(database);
+            var action = new GameConfSyncAction();
 
             action.ApplyToGameFile(gameFile, reader, new string[0]);
 
@@ -55,7 +41,7 @@ namespace UnitTest.Tests
             Tree files = new Tree("root", new Tree("GAMECONF",
                 "{\"data\": { \"author\": \"Bob the Dog\" }} "));
             var reader = new TreeReader(files);
-            var action = new GameConfSyncAction(database);
+            var action = new GameConfSyncAction();
 
             action.ApplyToGameFile(gameFile, reader, new string[0]);
 
@@ -74,7 +60,7 @@ namespace UnitTest.Tests
             Tree files = new Tree("root", new Tree("GAMECONF",
                 "{\"data\": { \"description\": \"A fancy dog.\" }} "));
             var reader = new TreeReader(files);
-            var action = new GameConfSyncAction(database);
+            var action = new GameConfSyncAction();
 
             action.ApplyToGameFile(gameFile, reader, new string[0]);
 
@@ -82,24 +68,21 @@ namespace UnitTest.Tests
         }
 
         [TestMethod]
-        public void ApplyToGameFile_SetsIwad()
+        public void ApplyToGameFile_SetsIntendedGame()
         {
             GameFile gameFile = new GameFile
             {
                 GameFileID = 1,
             };
 
-            database.InsertIWad(new IWadData { Name = "doom2.zip" });
-            var iwadId = database.GetIWads().FirstOrDefault(x => x.Name == "doom2.zip").IWadID;
-
             Tree files = new Tree("root", new Tree("GAMECONF",
                 "{\"data\": { \"iwad\": \"doom2.wad\" }} "));
             var reader = new TreeReader(files);
-            var action = new GameConfSyncAction(database);
+            var action = new GameConfSyncAction();
 
             action.ApplyToGameFile(gameFile, reader, new string[0]);
 
-            Assert.AreEqual(iwadId, gameFile.IWadID);
+            Assert.AreEqual(IWadInfo.DOOM2, gameFile.IntendedGame);
         }
 
         [TestMethod]
@@ -114,7 +97,7 @@ namespace UnitTest.Tests
             Tree files = new Tree("root", new Tree("WADINFO",
                 "{\"data\": { \"title\": \"Eviternity\" }} "));
             var reader = new TreeReader(files);
-            var action = new GameConfSyncAction(database);
+            var action = new GameConfSyncAction();
 
             action.ApplyToGameFile(gameFile, reader, new string[0]);
 

--- a/UnitTest/Tests/TestGameConfSyncAction.cs
+++ b/UnitTest/Tests/TestGameConfSyncAction.cs
@@ -82,7 +82,7 @@ namespace UnitTest.Tests
 
             action.ApplyToGameFile(gameFile, reader, new string[0]);
 
-            Assert.AreEqual(IWadInfo.DOOM2, gameFile.IntendedGame);
+            Assert.AreEqual(IWadInfo.Doom2, gameFile.IntendedGame);
         }
 
         [TestMethod]

--- a/UnitTest/Tests/TestGameFile.cs
+++ b/UnitTest/Tests/TestGameFile.cs
@@ -44,7 +44,9 @@ namespace UnitTest.Tests
                 SettingsMap = "the settings map" + salt,
                 SettingsSkill = "the settings skill" + salt,
                 SettingsSpecificFiles = "the settings specific files" + salt,
-                SettingsGameProfileID = 567 + salt
+                SettingsGameProfileID = 567 + salt,
+                IntendedGame = IWadInfo.DOOM2,
+                IsSyncNeeded = false
             };
 
             return gameFile;
@@ -89,7 +91,9 @@ namespace UnitTest.Tests
                 SettingsMap = "settings map",
                 SettingsSkill = "settings skill",
                 SettingsSpecificFiles = "ssf",
-                SettingsGameProfileID = 44
+                SettingsGameProfileID = 44,
+                IntendedGame = IWadInfo.DOOM2,
+                IsSyncNeeded = true
             };
             database.InsertGameFile(gameFile1);
 
@@ -115,7 +119,9 @@ namespace UnitTest.Tests
                 SettingsMap = "eee",
                 SettingsSkill = "fff",
                 SettingsSpecificFiles = "ggg",
-                SettingsGameProfileID = null
+                SettingsGameProfileID = null,
+                IntendedGame = IWadInfo.DOOM,
+                IsSyncNeeded = false
             };
             database.InsertGameFile(gameFile2);
 

--- a/UnitTest/Tests/TestGameFile.cs
+++ b/UnitTest/Tests/TestGameFile.cs
@@ -45,7 +45,7 @@ namespace UnitTest.Tests
                 SettingsSkill = "the settings skill" + salt,
                 SettingsSpecificFiles = "the settings specific files" + salt,
                 SettingsGameProfileID = 567 + salt,
-                IntendedGame = IWadInfo.DOOM2,
+                IntendedGame = IWadInfo.Doom2,
                 IsSyncNeeded = false
             };
 
@@ -92,7 +92,7 @@ namespace UnitTest.Tests
                 SettingsSkill = "settings skill",
                 SettingsSpecificFiles = "ssf",
                 SettingsGameProfileID = 44,
-                IntendedGame = IWadInfo.DOOM2,
+                IntendedGame = IWadInfo.Doom2,
                 IsSyncNeeded = true
             };
             database.InsertGameFile(gameFile1);
@@ -120,7 +120,7 @@ namespace UnitTest.Tests
                 SettingsSkill = "fff",
                 SettingsSpecificFiles = "ggg",
                 SettingsGameProfileID = null,
-                IntendedGame = IWadInfo.DOOM,
+                IntendedGame = IWadInfo.Doom,
                 IsSyncNeeded = false
             };
             database.InsertGameFile(gameFile2);

--- a/UnitTest/Tests/TestGameFileTags.cs
+++ b/UnitTest/Tests/TestGameFileTags.cs
@@ -44,7 +44,7 @@ namespace UnitTest.Tests
                 SettingsSkill = "the settings skill",
                 SettingsSpecificFiles = "the settings specific files",
                 SettingsGameProfileID = 567,
-                IntendedGame = IWadInfo.DOOM2
+                IntendedGame = IWadInfo.Doom2
             };
 
             return gameFile;

--- a/UnitTest/Tests/TestGameFileTags.cs
+++ b/UnitTest/Tests/TestGameFileTags.cs
@@ -43,7 +43,8 @@ namespace UnitTest.Tests
                 SettingsMap = "the settings map",
                 SettingsSkill = "the settings skill",
                 SettingsSpecificFiles = "the settings specific files",
-                SettingsGameProfileID = 567
+                SettingsGameProfileID = 567,
+                IntendedGame = IWadInfo.DOOM2
             };
 
             return gameFile;

--- a/UnitTest/Tests/TestGameInfoSyncAction.cs
+++ b/UnitTest/Tests/TestGameInfoSyncAction.cs
@@ -41,7 +41,7 @@ namespace UnitTest.Tests
 
             var result = syncAction.ApplyToGameFile(gameFile, reader, new string[0]);
 
-            Assert.AreEqual(IWadInfo.HERETIC, gameFile.IntendedGame);
+            Assert.AreEqual(IWadInfo.Heretic, gameFile.IntendedGame);
         }
 
         [TestMethod]

--- a/UnitTest/Tests/TestGameInfoSyncAction.cs
+++ b/UnitTest/Tests/TestGameInfoSyncAction.cs
@@ -1,4 +1,5 @@
-﻿using DoomLauncher.DataSources;
+﻿using DoomLauncher;
+using DoomLauncher.DataSources;
 using DoomLauncher.Handlers.Sync;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -24,6 +25,64 @@ namespace UnitTest.Tests
 
             Assert.AreEqual("The Big Tree", gameFile.Title);
         }
+
+        [TestMethod]
+        public void ApplyToGameFile_FindsIntendedGameInGAMEINFO()
+        {
+            var gameFile = new GameFile()
+            {
+                FileName = "blah.wad"
+            };
+
+            var syncAction = new GameInfoSyncAction();
+
+            Tree files = new Tree("root", new Tree("GAMEINFO", "FIRSTTHING=\"meh\"\nIWAD = \"heretic.wad\"\nSOMETHING_ELSE = blah"));
+            var reader = new TreeReader(files);
+
+            var result = syncAction.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.AreEqual(IWadInfo.HERETIC, gameFile.IntendedGame);
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_TakesTheLastKeyWhenDuplicated()
+        {
+            var gameFile = new GameFile()
+            {
+                FileName = "blah.wad",
+                Title = "Wrong title"
+            };
+
+            var syncAction = new GameInfoSyncAction();
+
+            Tree files = new Tree("root", new Tree("GAMEINFO", "STARTUPTITLE=\"title1\"\nSTARTUPTITLE = \"title2\""));
+            var reader = new TreeReader(files);
+
+            var result = syncAction.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.AreEqual("title2", gameFile.Title);
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_IgnoresWhitespaceTitle()
+        {
+            var gameFile = new GameFile()
+            {
+                FileName = "blah.wad",
+                Title = "Old title"
+            };
+
+            var syncAction = new GameInfoSyncAction();
+
+            Tree files = new Tree("root", new Tree("GAMEINFO", "STARTUPTITLE=\"    \""));
+            var reader = new TreeReader(files);
+
+            var result = syncAction.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.AreEqual("Old title", gameFile.Title);
+        }
+
+
 
         [TestMethod]
         public void ApplyToGameFile_FindsTitleInGAMEINFOTxt()

--- a/UnitTest/Tests/TestIntendedIwadSyncAction.cs
+++ b/UnitTest/Tests/TestIntendedIwadSyncAction.cs
@@ -32,10 +32,10 @@ namespace UnitTest.Tests
             var gameFile = new GameFile()
             {
                 FileName = "blah.wad",
-                IntendedGame = IWadInfo.HERETIC
+                IntendedGame = IWadInfo.Heretic
             };
 
-            var expectedIwad = CreateIWad(IWadInfo.HERETIC);
+            var expectedIwad = CreateIWad(IWadInfo.Heretic);
 
             var syncAction = new IntendedIwadSyncAction(database);
 
@@ -53,10 +53,10 @@ namespace UnitTest.Tests
             var gameFile = new GameFile()
             {
                 FileName = "diamond.wad",
-                IntendedGame = IWadInfo.DOOM2
+                IntendedGame = IWadInfo.Doom2
             };
 
-            var backupIWad = CreateIWad(IWadInfo.FREEDOOM2);
+            var backupIWad = CreateIWad(IWadInfo.FreeDoom2);
 
             var syncAction = new IntendedIwadSyncAction(database);
 

--- a/UnitTest/Tests/TestIntendedIwadSyncAction.cs
+++ b/UnitTest/Tests/TestIntendedIwadSyncAction.cs
@@ -1,0 +1,98 @@
+﻿using DoomLauncher;
+using DoomLauncher.DataSources;
+using DoomLauncher.Handlers.Sync;
+using DoomLauncher.Interfaces;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace UnitTest.Tests
+{
+    [TestClass]
+    public class TestIntendedIwadSyncAction
+    {
+        private IDataSourceAdapter database;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            database = TestUtil.CreateAdapter();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            var dataAccess = ((DbDataSourceAdapter)database).DataAccess;
+            dataAccess.ExecuteNonQuery("delete from GameFiles");
+            dataAccess.ExecuteNonQuery("delete from IWads");
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_FindsIWadMatchingIntendedGame()
+        {
+            var gameFile = new GameFile()
+            {
+                FileName = "blah.wad",
+                IntendedGame = IWadInfo.HERETIC
+            };
+
+            var expectedIwad = CreateIWad(IWadInfo.HERETIC);
+
+            var syncAction = new IntendedIwadSyncAction(database);
+
+            Tree files = new Tree("root", new Tree("entry1" ));
+            var reader = new TreeReader(files);
+
+            syncAction.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.AreEqual(expectedIwad.IWadID, gameFile.IWadID);
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_FindsBackupIWadMatchingIntendedGameIfIwadIsMissing()
+        {
+            var gameFile = new GameFile()
+            {
+                FileName = "diamond.wad",
+                IntendedGame = IWadInfo.DOOM2
+            };
+
+            var backupIWad = CreateIWad(IWadInfo.FREEDOOM2);
+
+            var syncAction = new IntendedIwadSyncAction(database);
+
+            Tree files = new Tree("root", new Tree("entry1"));
+            var reader = new TreeReader(files);
+
+            syncAction.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.AreEqual(backupIWad.IWadID, gameFile.IWadID);
+        }
+
+        private IIWadData CreateIWad(IWadInfo iwadInfo)
+        {
+            var fileName = iwadInfo.FileName;
+            var gameFile0 = new GameFile()
+            {
+                FileName = iwadInfo.FileName,
+                Title = iwadInfo.Title
+            };
+            database.InsertGameFile(gameFile0);
+            var gameFile1 = database.GetGameFile(fileName);
+
+            var iwad0 = new IWadData()
+            {
+                FileName = fileName,
+                Name = iwadInfo.Title,
+                GameFileID = gameFile1.GameFileID
+            };
+            database.InsertIWad(iwad0);
+            var iwad = database.GetIWad(gameFile1.GameFileID ?? -1);
+
+            gameFile1.IWadID = iwad.IWadID;
+            database.UpdateGameFile(gameFile1);
+
+            return iwad;
+        }
+
+    }
+}

--- a/UnitTest/Tests/TestSyncLibraryHandler.cs
+++ b/UnitTest/Tests/TestSyncLibraryHandler.cs
@@ -416,6 +416,31 @@ namespace UnitTest.Tests
             Assert.AreEqual(addedFile.Map, "MAP01");
         }
 
+        [TestMethod]
+        public void SyncClearsTheIsSyncNeededFlag()
+        {
+            SyncLibraryHandler handler = CreateSyncLibraryHandler();
+            Assert.AreEqual(0, database.GetGameFilesCount());
+
+            // Establish existing file
+            string file = "uroburos.zip";
+            File.Copy(Path.Combine("Resources", file), Path.Combine(s_filedir, file));
+            var syncResult = handler.SyncManyFiles(new string[] { "uroburos.zip" });
+            Assert.AreEqual(1, database.GetGameFilesCount());
+            
+            // Set IsSyncNeeded = true
+            var gameFile = database.GetGameFile("uroburos.zip");
+            gameFile.IsSyncNeeded = true;
+            database.UpdateGameFile(gameFile);
+            gameFile = database.GetGameFile("uroburos.zip");
+            Assert.IsTrue(gameFile.IsSyncNeeded);
+
+            syncResult = handler.SyncManyFiles(new string[] { "uroburos.zip" });
+
+            gameFile = database.GetGameFile("uroburos.zip");
+            Assert.IsFalse(gameFile.IsSyncNeeded);
+        }
+
         private SyncLibraryHandler CreateSyncLibraryHandler(bool pullTitlepic = false, FileManagement fileManagement = FileManagement.Managed)
         {
             var directories = new DirectoriesConfiguration 

--- a/UnitTest/Tests/TestTextFileSyncAction.cs
+++ b/UnitTest/Tests/TestTextFileSyncAction.cs
@@ -39,6 +39,7 @@ namespace UnitTest.Tests
             Assert.AreEqual("Child Mod", gameFile.Title);
             Assert.AreEqual("Radley Bobbikins", gameFile.Author);
             Assert.AreEqual(DateTime.Parse("4/3/2025"), gameFile.ReleaseDate);
+            Assert.AreEqual(IWadInfo.DOOM2, gameFile.IntendedGame);
 
             // Falls through to Child2 where missing from Child1
             Assert.AreEqual("A fine mod.", gameFile.Description);
@@ -72,6 +73,7 @@ namespace UnitTest.Tests
             Assert.IsTrue(string.IsNullOrEmpty(gameFile.Author));
             Assert.IsNull(gameFile.ReleaseDate);
             Assert.IsTrue(string.IsNullOrEmpty(gameFile.Description));
+            Assert.IsNull(gameFile.IntendedGame);
 
             // Low quality text file got used
             Assert.AreEqual("Low quality title", gameFile.Title);
@@ -104,6 +106,7 @@ namespace UnitTest.Tests
             Assert.AreEqual("Wadinfo title", gameFile.Title);
             Assert.AreEqual("Wadinfo author", gameFile.Author);
             Assert.AreEqual("WadInfo description", gameFile.Description);
+            Assert.AreEqual(IWadInfo.HERETIC, gameFile.IntendedGame);
         }
 
         [TestMethod]
@@ -116,10 +119,11 @@ namespace UnitTest.Tests
                 Title = "Too Many Imps",
                 ReleaseDate = DateTime.Parse("1/7/2021"),
                 Description = "A wad with too many imps",
+                IntendedGame = IWadInfo.HACX
             };
             Tree files = new Tree("root", new Tree("empty.txt"));
 
-            var syncAction = new TextFileSyncAction(str =>
+            var syncAction = new TextFileSyncAction(str => 
                 new IdGamesTextInfo(null, null, null, null, null));
 
             syncAction.ApplyToGameFile(gameFile, new TreeReader(files), new string[0]);
@@ -128,6 +132,7 @@ namespace UnitTest.Tests
             Assert.AreEqual("Fredericus", gameFile.Author);
             Assert.AreEqual(DateTime.Parse("1/7/2021"), gameFile.ReleaseDate);
             Assert.AreEqual("A wad with too many imps", gameFile.Description);
+            Assert.AreEqual(IWadInfo.HACX, gameFile.IntendedGame);
         }
     }
 }

--- a/UnitTest/Tests/TestTextFileSyncAction.cs
+++ b/UnitTest/Tests/TestTextFileSyncAction.cs
@@ -39,7 +39,7 @@ namespace UnitTest.Tests
             Assert.AreEqual("Child Mod", gameFile.Title);
             Assert.AreEqual("Radley Bobbikins", gameFile.Author);
             Assert.AreEqual(DateTime.Parse("4/3/2025"), gameFile.ReleaseDate);
-            Assert.AreEqual(IWadInfo.DOOM2, gameFile.IntendedGame);
+            Assert.AreEqual(IWadInfo.Doom2, gameFile.IntendedGame);
 
             // Falls through to Child2 where missing from Child1
             Assert.AreEqual("A fine mod.", gameFile.Description);
@@ -106,7 +106,7 @@ namespace UnitTest.Tests
             Assert.AreEqual("Wadinfo title", gameFile.Title);
             Assert.AreEqual("Wadinfo author", gameFile.Author);
             Assert.AreEqual("WadInfo description", gameFile.Description);
-            Assert.AreEqual(IWadInfo.HERETIC, gameFile.IntendedGame);
+            Assert.AreEqual(IWadInfo.Heretic, gameFile.IntendedGame);
         }
 
         [TestMethod]
@@ -119,7 +119,7 @@ namespace UnitTest.Tests
                 Title = "Too Many Imps",
                 ReleaseDate = DateTime.Parse("1/7/2021"),
                 Description = "A wad with too many imps",
-                IntendedGame = IWadInfo.HACX
+                IntendedGame = IWadInfo.Hacx
             };
             Tree files = new Tree("root", new Tree("empty.txt"));
 
@@ -132,7 +132,7 @@ namespace UnitTest.Tests
             Assert.AreEqual("Fredericus", gameFile.Author);
             Assert.AreEqual(DateTime.Parse("1/7/2021"), gameFile.ReleaseDate);
             Assert.AreEqual("A wad with too many imps", gameFile.Description);
-            Assert.AreEqual(IWadInfo.HACX, gameFile.IntendedGame);
+            Assert.AreEqual(IWadInfo.Hacx, gameFile.IntendedGame);
         }
     }
 }

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -91,6 +91,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Tests\TestIntendedIwadSyncAction.cs" />
     <Compile Include="Tests\Helpers\DirectoriesConfiguration.cs" />
     <Compile Include="Tests\TestDoom64SyncAction.cs" />
     <Compile Include="Tests\TestDoom64TitlePicSyncAction.cs" />


### PR DESCRIPTION
# 1. IsSyncNeeded feature
 - GameFile now has a boolean `IsSyncNeeded` field. This allows us to modify how syncing, thumbnail images, etc are generated and ensuring that users will see the new content next time they upgrade DoomLauncher
 - If set, the application will automatically lazily resync files as it displays them in the GUI
 - Works for both tile view & grid view
 - Where there are multiple pages, only resyncs the GameFiles in the displayed page
 - The DB upgrade sets it to 1 for all GameFiles, so as of the next release, users will have all their stuff automatically resynced
 - @nstlaurent btw would you mind letting me know when you plan to cut the next release? I'll make sure to cram as many sync improvements in as possible by then, to minimise the forced resyncing

# 2. IntendedGame feature
- GameFile now has an IntendedGame field. This is so we can judge what game the wad is supposed to be played with, even if they don't have that IWAD installed.
- Drops the `IsDoom64` field, which is now represented by `IntendedGame = DOOM64`
- IWadInfo has been upgraded into a Java-style enum (ie a real object, not an int), and the database maps the stored string into an IWadInfo. This keeps it typesafe, and makes sure we can't put junk into the string DB field. (I prefer to enforce this in the type system / code rather than SQLite)
- Drops the unused IWadInfo field `HasMetadata`
- Adds IWadInfo field `BackupGame` which means that Freedoom1 and Freedoom2 will automatically replace Doom1 and Doom2 respectively if they are not present.
- On sync, it tries a few things to guess the IntendedGame:
  - Looks for the "Game" field in text files and WADINFO
  - Looks for the "IWAD" field in GAMEINFO
  - Looks for the "iwad" field in GAMECONF
  - Last of all, it will set IWadId to the first matching IWad, if any
- I originally tried to use the existing (but unused) field `GameID`, but being an INTEGER, wasn't usable for this purpose.
- If required, `MainForm_Play` will confirm and apply the intended IWAD before play.

I have about 200 wads installed, including every Cacoward winner & runner up since 2018, and 75% of them get allocated a correct IntendedGame, including wads intended for Doom, Doom2, Heretic, TNT, Plutonia and of course Doom 64. I think we can eventually get to 100%, but this is a good start.