### PR TITLE
Mapinfo case fix

### DIFF
--- a/DoomLauncher/Handlers/Sync/MapStringGameFileFragment.cs
+++ b/DoomLauncher/Handlers/Sync/MapStringGameFileFragment.cs
@@ -12,8 +12,8 @@ namespace DoomLauncher.Handlers.Sync
     public class MapStringGameFileFragment : IGameFileFragment
     {
         private readonly LauncherPath m_tempDirectory;
-        private static readonly Regex MapRegex = new Regex(@"\s*map\s+\w+");
-        private static readonly Regex IncludeRegex = new Regex(@"\s*include\s+(\S+)");
+        private static readonly Regex MapRegex = new Regex(@"\s*map\s+\w+", RegexOptions.IgnoreCase);
+        private static readonly Regex IncludeRegex = new Regex(@"\s*include\s+(\S+)", RegexOptions.IgnoreCase);
 
         public MapStringGameFileFragment(LauncherPath tempDirectory)
         {
@@ -22,7 +22,7 @@ namespace DoomLauncher.Handlers.Sync
 
         public SyncResult ApplyToGameFile(IGameFile gameFile, IArchiveReader reader, string[] mapInfoData)
         {
-            var maps = GetMaps(gameFile, reader, mapInfoData);
+            var maps = GetMaps(reader, mapInfoData);
             var mapString = string.Join(", ", maps.ToArray());
 
             gameFile.Map = mapString;
@@ -32,7 +32,7 @@ namespace DoomLauncher.Handlers.Sync
             return SyncResult.EMPTY;
         }   
 
-        private List<string> GetMaps(IGameFile gameFile, IArchiveReader reader, string[] mapInfoData)
+        private List<string> GetMaps(IArchiveReader reader, string[] mapInfoData)
         {
             List<string> maps = new List<string>();
             if (mapInfoData.Length > 0)

--- a/UnitTest/Tests/TestMapStringGameFileFragment.cs
+++ b/UnitTest/Tests/TestMapStringGameFileFragment.cs
@@ -1,0 +1,33 @@
+﻿using DoomLauncher;
+using DoomLauncher.DataSources;
+using DoomLauncher.Handlers.Sync;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+
+namespace UnitTest.Tests
+{
+    [TestClass]
+    public class TestMapStringGameFileFragment
+    {
+        [TestMethod]
+        public void MapString()
+        {
+            var mapInfo = @"
+                map map01 {
+                    music = ""test1""
+                }
+
+                MAP MAP02 {
+                    music = ""test2""
+                }
+            ";
+
+            var frag = new MapStringGameFileFragment(new LauncherPath(Directory.GetCurrentDirectory()));
+            var gameFile = new GameFile();
+            frag.ApplyToGameFile(gameFile, null, new string[] { mapInfo });
+
+            Assert.AreEqual("map01, MAP02", gameFile.Map);
+            Assert.AreEqual(2, gameFile.MapCount);
+        }
+    }
+}


### PR DESCRIPTION
fix map regex to ignore case to fix maps not being loaded from mapinfo lumps with uppercase (eg MAP01 instead of map01)