### PR TITLE
Syncs title from GAMEINFO

### DIFF
--- a/DoomLauncher/DoomLauncher.csproj
+++ b/DoomLauncher/DoomLauncher.csproj
@@ -275,6 +275,7 @@
     <Compile Include="GameFileView\GameFileViewType.cs" />
     <Compile Include="Handlers\AutoCompleteCombo.cs" />
     <Compile Include="Handlers\Sync\Doom64TitlePicSyncAction.cs" />
+    <Compile Include="Handlers\Sync\GameInfoSyncAction.cs" />
     <Compile Include="Handlers\Sync\ISyncAction.cs" />
     <Compile Include="Handlers\Sync\MapInfoUtil.cs" />
     <Compile Include="Handlers\Sync\MapStringSyncAction.cs" />

--- a/DoomLauncher/Forms/MainForm_Sync.cs
+++ b/DoomLauncher/Forms/MainForm_Sync.cs
@@ -93,6 +93,7 @@ namespace DoomLauncher
                     new TextFileSyncAction(AppConfiguration.DateParseFormats),
                     new Doom64SyncAction(DataSourceAdapter),
                     new MapStringSyncAction(AppConfiguration.TempDirectory),
+                    new GameInfoSyncAction(),
                     new TitlePicSyncAction(DataCache.Instance.DefaultPalette, DataCache.Instance.HexenPalette).OnlyIf(AppConfiguration.AutomaticallyPullTitlpic),
                     new Doom64TitlePicSyncAction(),
                     new StartupImageSyncAction()

--- a/DoomLauncher/Handlers/Sync/GameInfoSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/GameInfoSyncAction.cs
@@ -1,0 +1,40 @@
+﻿using DoomLauncher.Interfaces;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace DoomLauncher.Handlers.Sync
+{
+    /// <summary>
+    /// https://zdoom.org/wiki/GAMEINFO
+    /// </summary>
+    public class GameInfoSyncAction : ISyncAction
+    {
+        private static readonly Regex STARTUPTITLE_REGEX = new Regex(@"\s*STARTUPTITLE\s*=\s*"".*"""); //@"\s*{0}\s*:[^=]*";
+        private static readonly Regex SUBTRACT_REGEX = new Regex(@"\s*STARTUPTITLE\s*=\s*");
+
+        public SyncResult ApplyToGameFile(IGameFile gameFile, IArchiveReader reader, string[] mapInfoData)
+        {
+            // Normally it's GAMEINFO, but I've seen GAMEINFO.txt in the wild. 
+            var entry = reader.Entries.FirstOrDefault(x => x.Name.ToLower().StartsWith("gameinfo"));
+            if (entry != null)
+            {
+                var text = entry.ReadString(Encoding.UTF7);
+                Match m = STARTUPTITLE_REGEX.Match(text);
+                if (m.Success)
+                {
+                    var fullStatement = m.Value;
+                    var assignment = SUBTRACT_REGEX.Match(fullStatement);
+                    if (assignment.Success)
+                    {
+                        var title = fullStatement.Substring(assignment.Length + 1, fullStatement.Length - assignment.Length - 2).Trim();
+                        if (!string.IsNullOrEmpty(title))
+                            gameFile.Title = title;
+                    }
+                }
+            }
+
+            return SyncResult.EMPTY;
+        }
+    }
+}

--- a/DoomLauncher/Handlers/Util.cs
+++ b/DoomLauncher/Handlers/Util.cs
@@ -510,6 +510,9 @@ namespace DoomLauncher
             return (attr & FileAttributes.Directory) == FileAttributes.Directory;
         }
 
+        public static string ReadString(this IArchiveEntry entry, Encoding encoding) =>
+            encoding.GetString(ReadEntry(entry));
+
         public static byte[] ReadEntry(this IArchiveEntry entry)
         {
             byte[] data = new byte[entry.Length];

--- a/UnitTest/Tests/TestGameInfoSyncAction.cs
+++ b/UnitTest/Tests/TestGameInfoSyncAction.cs
@@ -1,0 +1,64 @@
+﻿using DoomLauncher.DataSources;
+using DoomLauncher.Handlers.Sync;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTest.Tests
+{
+    [TestClass]
+    public class TestGameInfoSyncAction
+    {
+        [TestMethod]
+        public void ApplyToGameFile_FindsTitleInGAMEINFO()
+        {
+            var gameFile = new GameFile()
+            {
+                FileName = "blah.wad"
+            };
+
+            var syncAction = new GameInfoSyncAction();
+
+            Tree files = new Tree("root", new Tree("GAMEINFO", "IWAD = \"blah.wad\"\nSTARTUPTITLE  = \"The Big Tree\"\nSOMETHING_ELSE = blah"));
+            var reader = new TreeReader(files);
+
+            var result = syncAction.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.AreEqual("The Big Tree", gameFile.Title);
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_FindsTitleInGAMEINFOTxt()
+        {
+            var gameFile = new GameFile()
+            {
+                FileName = "blah.wad"
+            };
+
+            var syncAction = new GameInfoSyncAction();
+
+            Tree files = new Tree("root", new Tree("GAMEINFO.txt", "IWAD = \"blah.wad\"\nSTARTUPTITLE  = \"The Big Banana\"\nSOMETHING_ELSE = blah"));
+            var reader = new TreeReader(files);
+
+            var result = syncAction.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.AreEqual("The Big Banana", gameFile.Title);
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_DoesntFindsTitleInAFileCalledSomethingElse()
+        {
+            var gameFile = new GameFile()
+            {
+                FileName = "blah.wad"
+            };
+
+            var syncAction = new GameInfoSyncAction();
+
+            Tree files = new Tree("root", new Tree("GAMEINF", "IWAD = \"blah.wad\"\nSTARTUPTITLE  = \"The Big Banana\"\nSOMETHING_ELSE = blah"));
+            var reader = new TreeReader(files);
+
+            var result = syncAction.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.IsTrue(string.IsNullOrEmpty(gameFile.Title));
+        }
+    }
+}

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Tests\Helpers\DirectoriesConfiguration.cs" />
     <Compile Include="Tests\TestDoom64SyncAction.cs" />
     <Compile Include="Tests\TestDoom64TitlePicSyncAction.cs" />
+    <Compile Include="Tests\TestGameInfoSyncAction.cs" />
     <Compile Include="Tests\TestMapStringSyncAction.cs" />
     <Compile Include="Tests\TestRecursiveArchiveReader.cs" />
     <Compile Include="Tests\TestGameStoreFiles.cs" />


### PR DESCRIPTION
There are lots of things we can get from GAMEINFO (or gameinfo.txt), but for the time being we are just bringing in the title. If non-empty & non-whitespace, this is considered to be a higher priority source of "title" than the various txt files. 

Example: [TNT 2: Devilution](https://www.doomworld.com/vb/thread/104882) (🥇2023). Previously the title was garbage that fell out of a random text file