### PR TITLE
GAMECONF sync action support

### DIFF
--- a/DoomLauncher/DoomLauncher.csproj
+++ b/DoomLauncher/DoomLauncher.csproj
@@ -275,6 +275,7 @@
     <Compile Include="GameFileView\GameFileViewType.cs" />
     <Compile Include="Handlers\AutoCompleteCombo.cs" />
     <Compile Include="Handlers\Sync\Doom64TitlePicSyncAction.cs" />
+    <Compile Include="Handlers\Sync\GameConfSyncAction.cs" />
     <Compile Include="Handlers\Sync\GameInfoSyncAction.cs" />
     <Compile Include="Handlers\Sync\ISyncAction.cs" />
     <Compile Include="Handlers\Sync\IWadTitlesSyncAction.cs" />

--- a/DoomLauncher/Forms/MainForm_Sync.cs
+++ b/DoomLauncher/Forms/MainForm_Sync.cs
@@ -95,11 +95,11 @@ namespace DoomLauncher
                     new Doom64SyncAction(DataSourceAdapter),
                     new MapStringSyncAction(AppConfiguration.TempDirectory),
                     new GameInfoSyncAction(),
+                    new StartupImageSyncAction(),
                     new TitlePicSyncAction(DataCache.Instance.DefaultPalette, DataCache.Instance.HexenPalette).OnlyIf(AppConfiguration.AutomaticallyPullTitlpic),
                     new Doom64TitlePicSyncAction(),
-                    new StartupImageSyncAction(),
                     new IWadTitlesSyncAction(),
-                    new GameConfSyncAction(DataSourceAdapter),
+                    new GameConfSyncAction(DataSourceAdapter)
                 };
 
                 handler = new SyncLibraryHandler(DataSourceAdapter, DirectoryDataSourceAdapter, AppConfiguration, 

--- a/DoomLauncher/Forms/MainForm_Sync.cs
+++ b/DoomLauncher/Forms/MainForm_Sync.cs
@@ -90,6 +90,7 @@ namespace DoomLauncher
             {
                 var syncActions = new List<ISyncAction>()
                 {
+                    // Lower on the list is higher priority
                     new TextFileSyncAction(AppConfiguration.DateParseFormats),
                     new Doom64SyncAction(DataSourceAdapter),
                     new MapStringSyncAction(AppConfiguration.TempDirectory),
@@ -97,7 +98,8 @@ namespace DoomLauncher
                     new TitlePicSyncAction(DataCache.Instance.DefaultPalette, DataCache.Instance.HexenPalette).OnlyIf(AppConfiguration.AutomaticallyPullTitlpic),
                     new Doom64TitlePicSyncAction(),
                     new StartupImageSyncAction(),
-                    new IWadTitlesSyncAction()
+                    new IWadTitlesSyncAction(),
+                    new GameConfSyncAction(DataSourceAdapter),
                 };
 
                 handler = new SyncLibraryHandler(DataSourceAdapter, DirectoryDataSourceAdapter, AppConfiguration, 

--- a/DoomLauncher/Handlers/Sync/GameConfSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/GameConfSyncAction.cs
@@ -1,0 +1,65 @@
+﻿using DoomLauncher.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Web.Script.Serialization;
+
+namespace DoomLauncher.Handlers.Sync
+{
+    public class GameConfSyncAction : ISyncAction
+    {
+        private readonly IDataSourceAdapter m_database;
+
+        public GameConfSyncAction(IDataSourceAdapter database)
+        {
+            m_database = database;
+        }
+
+        public SyncResult ApplyToGameFile(IGameFile gameFile, IArchiveReader reader, string[] mapInfoData)
+        {
+            var entry = reader.Entries.FirstOrDefault(e => e.Name.ToLower().Equals("gameconf"));
+            if (entry != null)
+            {
+                var json = entry.ReadString(Encoding.UTF7);
+
+                try
+                {
+                    var serializer = new JavaScriptSerializer();
+                    var gameConfData = serializer.Deserialize<Dictionary<string, object>>(json);
+
+                    var data = (Dictionary<string, object>)gameConfData["data"];
+                    var title = data.ContainsKey("title") ? data["title"] as string : null;
+                    var author = data.ContainsKey("author") ? data["author"] as string : null;
+                    var description = data.ContainsKey("description") ? data["description"] as string : null;
+                    var iwad = data.ContainsKey("iwad") ? data["iwad"] as string : null;
+
+                    if (!string.IsNullOrEmpty(title))
+                        gameFile.Title = title;
+
+                    if (!string.IsNullOrEmpty(author))
+                        gameFile.Author = author;
+
+                    if (!string.IsNullOrEmpty(description))
+                        gameFile.Description = description;
+
+                    if (!string.IsNullOrEmpty(iwad))
+                    {
+                        var gameName = Path.GetFileNameWithoutExtension(iwad.ToLower());
+                        var iwadFile = m_database.GetIWads().FirstOrDefault(x =>
+                            Path.GetFileNameWithoutExtension(x.Name.ToLower()).Equals(gameName));
+                        if (iwadFile != null)
+                            gameFile.IWadID = iwadFile.IWadID;
+                    }
+                }
+                catch (Exception ex)
+                {
+
+                }
+            }
+
+            return SyncResult.EMPTY;
+        }
+    }
+}

--- a/DoomLauncher/Handlers/Sync/SyncResult.cs
+++ b/DoomLauncher/Handlers/Sync/SyncResult.cs
@@ -42,7 +42,7 @@ namespace DoomLauncher.Handlers.Sync
                 addedGameFiles: CombineLists(AddedGameFiles, other.AddedGameFiles),
                 updatedGameFiles: CombineLists(UpdatedGameFiles, other.UpdatedGameFiles),
                 invalidFiles: CombineLists(InvalidFiles, other.InvalidFiles),
-                titlePics: CombineDictionariesKeepFirst(TitlePics, other.TitlePics),
+                titlePics: CombineDictionariesKeepLatest(TitlePics, other.TitlePics),
                 failedTitlePicFiles: CombineLists(FailedTitlePicFiles, other.FailedTitlePicFiles));
         }
 
@@ -109,13 +109,13 @@ namespace DoomLauncher.Handlers.Sync
         }
 
         // Keep the existing key/values
-        private static Dictionary<K, V> CombineDictionariesKeepFirst<K, V>(Dictionary<K, V> ourDict, Dictionary<K, V> otherDict)
+        private static Dictionary<K, V> CombineDictionariesKeepLatest<K, V>(Dictionary<K, V> ourDict, Dictionary<K, V> otherDict)
         {
-            var combinedDictionary = new Dictionary<K, V>(ourDict);
-            foreach (var key in otherDict.Keys)
+            var combinedDictionary = new Dictionary<K, V>(otherDict);
+            foreach (var key in ourDict.Keys)
             {
                 if (!combinedDictionary.ContainsKey(key))
-                    combinedDictionary[key] = otherDict[key];
+                    combinedDictionary[key] = ourDict[key];
             }
             return combinedDictionary;
         }

--- a/UnitTest/Tests/TestGameConfSyncAction.cs
+++ b/UnitTest/Tests/TestGameConfSyncAction.cs
@@ -1,0 +1,125 @@
+﻿using DoomLauncher;
+using DoomLauncher.DataSources;
+using DoomLauncher.Handlers.Sync;
+using DoomLauncher.Interfaces;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace UnitTest.Tests
+{
+    [TestClass]
+    public class TestGameConfSyncAction
+    {
+        private DbDataSourceAdapter database;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            database = (DbDataSourceAdapter)TestUtil.CreateAdapter();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            database.DataAccess.ExecuteNonQuery("delete from IWads");
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_SetsTitle()
+        {
+            GameFile gameFile = new GameFile 
+            { 
+                GameFileID = 1,
+                Title = "Wrong Title",
+            };
+
+            Tree files = new Tree("root", new Tree("GAMECONF", 
+                "{\"data\": { \"title\": \"Bingo Bongo\" }} "));
+            var reader = new TreeReader(files);
+            var action = new GameConfSyncAction(database);
+
+            action.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.AreEqual("Bingo Bongo", gameFile.Title);
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_SetsAuthor()
+        {
+            GameFile gameFile = new GameFile
+            {
+                GameFileID = 1,
+                Author = "Wrong Author",
+            };
+
+            Tree files = new Tree("root", new Tree("GAMECONF",
+                "{\"data\": { \"author\": \"Bob the Dog\" }} "));
+            var reader = new TreeReader(files);
+            var action = new GameConfSyncAction(database);
+
+            action.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.AreEqual("Bob the Dog", gameFile.Author);
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_SetsDescription()
+        {
+            GameFile gameFile = new GameFile
+            {
+                GameFileID = 1,
+                Description = "Wrong Description",
+            };
+
+            Tree files = new Tree("root", new Tree("GAMECONF",
+                "{\"data\": { \"description\": \"A fancy dog.\" }} "));
+            var reader = new TreeReader(files);
+            var action = new GameConfSyncAction(database);
+
+            action.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.AreEqual("A fancy dog.", gameFile.Description);
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_SetsIwad()
+        {
+            GameFile gameFile = new GameFile
+            {
+                GameFileID = 1,
+            };
+
+            database.InsertIWad(new IWadData { Name = "doom2.zip" });
+            var iwadId = database.GetIWads().FirstOrDefault(x => x.Name == "doom2.zip").IWadID;
+
+            Tree files = new Tree("root", new Tree("GAMECONF",
+                "{\"data\": { \"iwad\": \"doom2.wad\" }} "));
+            var reader = new TreeReader(files);
+            var action = new GameConfSyncAction(database);
+
+            action.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.AreEqual(iwadId, gameFile.IWadID);
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_IgnoresAbsentGAMECONF()
+        {
+            GameFile gameFile = new GameFile
+            {
+                GameFileID = 1,
+                Title = "Old Title",
+            };
+
+            Tree files = new Tree("root", new Tree("WADINFO",
+                "{\"data\": { \"title\": \"Eviternity\" }} "));
+            var reader = new TreeReader(files);
+            var action = new GameConfSyncAction(database);
+
+            action.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.AreEqual("Old Title", gameFile.Title);
+        }
+
+    }
+}

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Tests\Helpers\DirectoriesConfiguration.cs" />
     <Compile Include="Tests\TestDoom64SyncAction.cs" />
     <Compile Include="Tests\TestDoom64TitlePicSyncAction.cs" />
+    <Compile Include="Tests\TestGameConfSyncAction.cs" />
     <Compile Include="Tests\TestGameInfoSyncAction.cs" />
     <Compile Include="Tests\TestIWadTitlesSyncAction.cs" />
     <Compile Include="Tests\TestMapStringSyncAction.cs" />


### PR DESCRIPTION
OK, one more. 

This consumes the GAMECONF lump, parsing the JSON to get title, author, description and IWAD. 

The only ones I know of that use this are: 
- Master Levels
- No Rest For the Living
- Sigil
- Sigil II 

So this helps out a lot with the official releases, even if it doesn't seem to be widely used by the community.

Also: 
Fixing a subtle bug in the sync actions, where the titlepics that accumulate in the SyncResult make the first value win, but any changes to the GameFile overwrite previous values. This meant that the order that the SyncActions are listed in MainForm_Sync had a confusing effect on priority. Now: later always = higher priority.