### PR TITLE
Text file sync will also look at WADFILE lumps

### DIFF
--- a/DoomLauncher/Forms/MainForm_Sync.cs
+++ b/DoomLauncher/Forms/MainForm_Sync.cs
@@ -91,7 +91,7 @@ namespace DoomLauncher
                 var syncActions = new List<ISyncAction>()
                 {
                     // Lower on the list is higher priority
-                    new TextFileSyncAction(AppConfiguration.DateParseFormats),
+                    new TextFileSyncAction(new IdGamesTextFileParser(AppConfiguration.DateParseFormats).Parse),
                     new Doom64SyncAction(DataSourceAdapter),
                     new MapStringSyncAction(AppConfiguration.TempDirectory),
                     new GameInfoSyncAction(),

--- a/DoomLauncher/Handlers/Sync/TextFileSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/TextFileSyncAction.cs
@@ -8,36 +8,47 @@ namespace DoomLauncher.Handlers.Sync
 {
     public class TextFileSyncAction : ISyncAction
     {
-        private readonly string[] m_dateParseFormats;
+        private readonly Func<string, IdGamesTextInfo> m_parseTextFile;
 
-        public TextFileSyncAction(string[] dateParseFormats) 
+        public TextFileSyncAction(Func<string, IdGamesTextInfo> parseTextFile)
         {
-            m_dateParseFormats = dateParseFormats;
+            m_parseTextFile = parseTextFile;
         }
 
-        public SyncResult ApplyToGameFile(IGameFile file, IArchiveReader reader, string[] mapInfoData)
-        {
-            FillTextFileInfo(file, reader);
-            return SyncResult.EMPTY;
-        }
-
-        private void FillTextFileInfo(IGameFile gameFile, IArchiveReader reader)
+        public SyncResult ApplyToGameFile(IGameFile gameFile, IArchiveReader reader, string[] mapInfoData)
         {
             var textInfos = from entry in reader.Entries
-                            where isTxtFile(entry.FullName)
-                            let info = ParseIdGamesTextInfo(entry)
+                            where isTxtFile(entry.FullName) || entry.FullName.ToLower().Equals("wadinfo")
+                            let info = m_parseTextFile(entry.ReadString(Encoding.UTF7))
                             orderby info.QualityScore descending
                             select info;
 
+
             var bestInfo = textInfos.Aggregate(IdGamesTextInfo.EMPTY, (a, b) => a.Combine(b));
 
-            gameFile.Title = bestInfo.Title;
-            gameFile.Author = bestInfo.Author;
-            gameFile.ReleaseDate = bestInfo.ReleaseDate;
-            gameFile.Description = bestInfo.Description;
+            if (!string.IsNullOrEmpty(bestInfo.Title))
+                gameFile.Title = bestInfo.Title;
+
+            if (!string.IsNullOrEmpty(bestInfo.Author))
+                gameFile.Author = bestInfo.Author;
+
+            if (bestInfo.ReleaseDate != null)
+                gameFile.ReleaseDate = bestInfo.ReleaseDate;
+
+            if (!string.IsNullOrEmpty(bestInfo.Description))
+                gameFile.Description = bestInfo.Description;
 
             if (string.IsNullOrWhiteSpace(gameFile.Title))
                 gameFile.Title = GetUserFriendlyFilename(gameFile.FileNameNoPath);
+
+            return SyncResult.EMPTY;
+        }
+
+        private string GetUserFriendlyFilename(string filename)
+        {
+            var words = Path.GetFileNameWithoutExtension(filename).Replace("_", " ").Replace("-", " ").Split();
+            var capitalisedWords = words.Select(word => string.Concat(word[0].ToString().ToUpper(), word.Substring(1)));
+            return string.Join(" ", capitalisedWords.ToArray());
         }
 
         private bool isTxtFile(string filename)
@@ -51,33 +62,5 @@ namespace DoomLauncher.Handlers.Sync
                 return false; // Path.GetExtension is a bit of a stickler, but we just need yes or no.
             }
         }
-
-        private IdGamesTextInfo ParseIdGamesTextInfo(IArchiveEntry entry)
-        {
-            string buffer = Encoding.UTF7.GetString(ReadBuffer(entry));
-            return new IdGamesTextFileParser(m_dateParseFormats).Parse(buffer);
-        }
-
-        private string GetUserFriendlyFilename(string filename)
-        {
-            var words = Path.GetFileNameWithoutExtension(filename).Replace("_", " ").Replace("-", " ").Split();
-            var capitalisedWords = words.Select(word => string.Concat(word[0].ToString().ToUpper(), word.Substring(1)));
-            return string.Join(" ", capitalisedWords.ToArray());
-        }
-
-        private byte[] ReadBuffer(IArchiveEntry entry)
-        {
-            byte[] buffer = new byte[entry.Length];
-            try
-            {
-                entry.Read(buffer, 0, Convert.ToInt32(entry.Length));
-            }
-            catch (Exception)
-            {
-                // Do not fail because we couldn't read a text file
-            }
-            return buffer;
-        }
-
     }
 }

--- a/UnitTest/Tests/TestSyncLibraryHandler.cs
+++ b/UnitTest/Tests/TestSyncLibraryHandler.cs
@@ -413,7 +413,7 @@ namespace UnitTest.Tests
 
             var syncActions = new List<ISyncAction>()
             {
-                new TextFileSyncAction(dateParseFormats),
+                new TextFileSyncAction(new IdGamesTextFileParser(dateParseFormats).Parse),
                 new Doom64SyncAction(database),
                 new MapStringSyncAction(directories.TempDirectory)
             };

--- a/UnitTest/Tests/TestTextFileSyncAction.cs
+++ b/UnitTest/Tests/TestTextFileSyncAction.cs
@@ -1,0 +1,133 @@
+﻿using DoomLauncher;
+using DoomLauncher.DataSources;
+using DoomLauncher.Handlers.Sync;
+using DoomLauncher.Interfaces;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace UnitTest.Tests
+{
+    [TestClass]
+    public class TestTextFileSyncAction
+    {
+
+        [TestMethod]
+        public void ApplyToGameFile_ChoosesHighestQualityAnswers()
+        {
+            IGameFile gameFile = new GameFile()
+            {
+                FileName = "banana.wad"
+            };
+            Tree files = new Tree("root", new Tree("child1.txt"), new Tree("child2.txt"));
+
+            var syncAction = new TextFileSyncAction(str =>
+            {
+                switch (str)
+                {
+                    case "child1.txt":
+                        return new IdGamesTextInfo("Child Mod", "Radley Bobbikins", DateTime.Parse("4/3/2025"), null, "DOOM2");
+                    case "child2.txt":
+                        return new IdGamesTextInfo("Wrong name", null, null, "A fine mod.", null);
+                    default:
+                        throw new Exception($"Unexpected entry {str}");
+                }
+            });
+
+            syncAction.ApplyToGameFile(gameFile, new TreeReader(files), new string[0]);
+
+            // Child1's fields are preferred, because it is higher quality
+            Assert.AreEqual("Child Mod", gameFile.Title);
+            Assert.AreEqual("Radley Bobbikins", gameFile.Author);
+            Assert.AreEqual(DateTime.Parse("4/3/2025"), gameFile.ReleaseDate);
+
+            // Falls through to Child2 where missing from Child1
+            Assert.AreEqual("A fine mod.", gameFile.Description);
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_IgnoresNonTextFiles()
+        {
+            IGameFile gameFile = new GameFile()
+            {
+                FileName = "something.wad"
+            };
+            Tree files = new Tree("root", new Tree("lowqual.txt"), new Tree("highqual1.bin"));
+
+            var syncAction = new TextFileSyncAction(str =>
+            {
+                switch (str)
+                {
+                    case "lowqual.txt":
+                        return new IdGamesTextInfo("Low quality title", null, null, null, null);
+                    case "highqual1.bin":
+                        return new IdGamesTextInfo("High Quality Mod", "Ernest Wallop", null, "Lots of description", "DOOM2");
+                    default:
+                        throw new Exception($"Unexpected entry {str}");
+                }
+            });
+
+            syncAction.ApplyToGameFile(gameFile, new TreeReader(files), new string[0]);
+
+            // The high quality file got ignored because it isn't .txt
+            Assert.IsTrue(string.IsNullOrEmpty(gameFile.Author));
+            Assert.IsNull(gameFile.ReleaseDate);
+            Assert.IsTrue(string.IsNullOrEmpty(gameFile.Description));
+
+            // Low quality text file got used
+            Assert.AreEqual("Low quality title", gameFile.Title);
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_ChecksWADINFO()
+        {
+            IGameFile gameFile = new GameFile()
+            {
+                FileName = "potato.wad"
+            };
+            Tree files = new Tree("root", new Tree("WADINFO"), new Tree("wadinfo"));
+
+            var syncAction = new TextFileSyncAction(str =>
+            {
+                switch (str)
+                {
+                    case "WADINFO":
+                        return new IdGamesTextInfo("Wadinfo title", null, null, null, "HERETIC");
+                    case "wadinfo":
+                        return new IdGamesTextInfo(null, "Wadinfo author", null, "WadInfo description", null);
+                    default:
+                        throw new Exception($"Unexpected entry {str}");
+                }
+            });
+
+            syncAction.ApplyToGameFile(gameFile, new TreeReader(files), new string[0]);
+
+            Assert.AreEqual("Wadinfo title", gameFile.Title);
+            Assert.AreEqual("Wadinfo author", gameFile.Author);
+            Assert.AreEqual("WadInfo description", gameFile.Description);
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_NullOrEmptyDataDoesntOverwriteGameFile()
+        {
+            IGameFile gameFile = new GameFile()
+            {
+                FileName = "imps.wad",
+                Author = "Fredericus",
+                Title = "Too Many Imps",
+                ReleaseDate = DateTime.Parse("1/7/2021"),
+                Description = "A wad with too many imps",
+            };
+            Tree files = new Tree("root", new Tree("empty.txt"));
+
+            var syncAction = new TextFileSyncAction(str =>
+                new IdGamesTextInfo(null, null, null, null, null));
+
+            syncAction.ApplyToGameFile(gameFile, new TreeReader(files), new string[0]);
+
+            Assert.AreEqual("Too Many Imps", gameFile.Title);
+            Assert.AreEqual("Fredericus", gameFile.Author);
+            Assert.AreEqual(DateTime.Parse("1/7/2021"), gameFile.ReleaseDate);
+            Assert.AreEqual("A wad with too many imps", gameFile.Description);
+        }
+    }
+}

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Tests\TestAutomaticSteamCheck.cs" />
     <Compile Include="Tests\TestStartupImageSyncAction.cs" />
     <Compile Include="Tests\TestSteamLoader.cs" />
+    <Compile Include="Tests\TestTextFileSyncAction.cs" />
     <Compile Include="Tests\TestUtil.cs" />
     <Compile Include="Tests\TestFile.cs" />
     <Compile Include="Tests\TestLoadFiles.cs" />


### PR DESCRIPTION
- WADFILE and WADFILE.txt lumps often contain similar info to idgames text files - so let's mine them for sync content too. 
- Minor refactor of TextFileSyncAction to make it more testable
- TextFileSync will no longer insist on badgering the GameFile about fields it couldn't find
- Unit tests covering all the logic in TextFileSyncAction