### PR TITLE
Streamlined tag menu, with inline toggles

### DIFF
--- a/DoomLauncher/Config/TagMapLookup.cs
+++ b/DoomLauncher/Config/TagMapLookup.cs
@@ -11,8 +11,8 @@ namespace DoomLauncher
 
         private readonly IDataSourceAdapter m_adapter;
 
-        private Dictionary<int, ITagMapping[]> m_fileTagMapping;
-        private Dictionary<int, ITagData> m_tags;
+        private Dictionary<int, ITagMapping[]> m_fileTagMapping; // GameFileID -> ITagMapping
+        private Dictionary<int, ITagData> m_tags; // TagID -> ITagData
 
         public TagMapLookup(IDataSourceAdapter adapter)
         {

--- a/DoomLauncher/Forms/MainForm.Designer.cs
+++ b/DoomLauncher/Forms/MainForm.Designer.cs
@@ -42,13 +42,9 @@
             this.updateMetadataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
             this.sortByToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectTagsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tagToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.newTagToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-            this.removeTagToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.manageTagsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
             this.utilityToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.manageUtilitiesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
@@ -149,9 +145,7 @@
             this.updateMetadataToolStripMenuItem,
             this.toolStripSeparator8,
             this.sortByToolStripMenuItem,
-            this.selectTagsToolStripMenuItem,
             this.tagToolStripMenuItem,
-            this.removeTagToolStripMenuItem,
             this.utilityToolStripMenuItem,
             this.toolStripSeparator5,
             this.deleteToolStripMenuItem,
@@ -232,13 +226,6 @@
             this.sortByToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
             this.sortByToolStripMenuItem.Text = "Sort By";
             // 
-            // selectTagsToolStripMenuItem
-            // 
-            this.selectTagsToolStripMenuItem.Name = "selectTagsToolStripMenuItem";
-            this.selectTagsToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
-            this.selectTagsToolStripMenuItem.Text = "Select Tags...";
-            this.selectTagsToolStripMenuItem.Click += new System.EventHandler(this.selectTagsToolStripMenuItem_Click);
-            // 
             // tagToolStripMenuItem
             // 
             this.tagToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -259,27 +246,6 @@
             // 
             this.toolStripSeparator6.Name = "toolStripSeparator6";
             this.toolStripSeparator6.Size = new System.Drawing.Size(149, 6);
-            // 
-            // removeTagToolStripMenuItem
-            // 
-            this.removeTagToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.manageTagsToolStripMenuItem1,
-            this.toolStripSeparator7});
-            this.removeTagToolStripMenuItem.Name = "removeTagToolStripMenuItem";
-            this.removeTagToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
-            this.removeTagToolStripMenuItem.Text = "Remove Tag";
-            // 
-            // manageTagsToolStripMenuItem1
-            // 
-            this.manageTagsToolStripMenuItem1.Name = "manageTagsToolStripMenuItem1";
-            this.manageTagsToolStripMenuItem1.Size = new System.Drawing.Size(152, 22);
-            this.manageTagsToolStripMenuItem1.Text = "Manage Tags...";
-            this.manageTagsToolStripMenuItem1.Click += new System.EventHandler(this.manageTagsToolStripMenuItem1_Click);
-            // 
-            // toolStripSeparator7
-            // 
-            this.toolStripSeparator7.Name = "toolStripSeparator7";
-            this.toolStripSeparator7.Size = new System.Drawing.Size(149, 6);
             // 
             // utilityToolStripMenuItem
             // 
@@ -989,9 +955,6 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
         private System.Windows.Forms.ToolStripMenuItem manageTagsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem removeTagToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem manageTagsToolStripMenuItem1;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
         private System.Windows.Forms.ToolStripMenuItem updateMetadataToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
         private System.Windows.Forms.ToolStripMenuItem showToolStripMenuItem;
@@ -1021,7 +984,6 @@
         private System.Windows.Forms.FlowLayoutPanel flpTags;
         private DoomLauncher.FormButton btnTags;
         private System.Windows.Forms.Label lblSelectedTag;
-        private System.Windows.Forms.ToolStripMenuItem selectTagsToolStripMenuItem;
         private System.Windows.Forms.SplitContainer splitTagSelect;
         private System.Windows.Forms.ToolStripMenuItem addDirectoryToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator15;

--- a/DoomLauncher/Forms/MainForm.cs
+++ b/DoomLauncher/Forms/MainForm.cs
@@ -2012,11 +2012,6 @@ namespace DoomLauncher
             HandleManageTags();
         }
 
-        private void manageTagsToolStripMenuItem1_Click(object sender, EventArgs e)
-        {
-            HandleManageTags();
-        }
-
         private void manageTagsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             HandleManageTags();
@@ -2286,89 +2281,28 @@ namespace DoomLauncher
                 MessageBox.Show(this, "The utility was an invalid application or not found.", "Invalid Utility", MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
-        private void selectTagsToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            IGameFile[] gameFiles = SelectedItems(GetCurrentViewControl());
-            if (gameFiles.Length == 0)
-                return;
-
-            TagSelectForm form = new TagSelectForm();
-            form.StartPosition = FormStartPosition.CenterParent;
-            form.TagSelectControl.Init(new TagSelectOptions() { ShowCheckBoxes = true });
-
-            if (gameFiles.Length == 1)
-            {
-                IGameFile gameFile = gameFiles[0];
-                ITagData[] existingTags = DataCache.Instance.TagMapLookup.GetTags(gameFile);
-
-                form.TagSelectControl.SetCheckedTags(existingTags);
-                if (form.ShowDialog(this) == DialogResult.OK)
-                {
-                    IGameFile[] updateGameFiles = new IGameFile[] { gameFile };
-                    DataCache.Instance.UpdateGameFileTags(updateGameFiles, form.TagSelectControl.GetCheckedTags());
-
-                    GetCurrentViewControl().UpdateGameFile(gameFile);
-                    HandleSelectionChange(GetCurrentViewControl(), true);
-                }
-
-                return;
-            }
-
-            if (form.ShowDialog(this) == DialogResult.OK)
-            {
-                DataCache.Instance.UpdateGameFileTags(gameFiles, form.TagSelectControl.GetCheckedTags());
-
-                foreach (var gameFile in gameFiles)
-                    GetCurrentViewControl().UpdateGameFile(gameFile);
-                HandleSelectionChange(GetCurrentViewControl(), true);
-            }
-        }
-
         private void tagToolStripItem_Click(object sender, EventArgs e)
         {
-            if (!(sender is ToolStripItem strip))
+            if (!(sender is ToolStripMenuItem strip))
                 return;
 
+            // This is the tag that was clicked
             ITagData tag = DataCache.Instance.Tags.FirstOrDefault(x => x.TagID.Equals(strip.Tag));
             if (tag == null)
                 return;
 
             IGameFile[] gameFiles = SelectedItems(GetCurrentViewControl());
-            DataCache.Instance.AddGameFileTag(gameFiles, tag, out List<IGameFile> alreadyTagged);
 
+            if (strip.Checked)
+                DataCache.Instance.AddGameFileTag(gameFiles, tag, out List<IGameFile> alreadyTagged);
+            else 
+                DataCache.Instance.RemoveGameFileTag(gameFiles, tag);
+
+            // Update mutable cache of tag mappings & publish an event
             DataCache.Instance.TagMapLookup.Refresh(new ITagData[] { tag });
             UpdateTagTabData(tag.TagID);
 
-            foreach (IGameFile gameFile in gameFiles)
-                GetCurrentViewControl().UpdateGameFile(gameFile);
-
-            if (alreadyTagged.Count > 0)
-            {
-                StringBuilder sbError = new StringBuilder(string.Join(", ", alreadyTagged.Select(x => x.FileNameNoPath).ToArray()));
-                sbError.Insert(0, "The file(s) ");
-                sbError.Append(" already have the tag ");
-                sbError.Append(tag.Name);
-                MessageBox.Show(this, sbError.ToString(), "Already Tagged", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-            }
-
-            HandleSelectionChange(GetCurrentViewControl(), true);
-        }
-
-        private void removeTagToolStripItem_Click(object sender, EventArgs e)
-        {
-            if (!(sender is ToolStripItem strip))
-                return;
-
-            ITagData tag = DataCache.Instance.Tags.FirstOrDefault(x => x.TagID.Equals(strip.Tag));
-            if (tag == null)
-                return;
-
-            IGameFile[] gameFiles = SelectedItems(GetCurrentViewControl());
-            DataCache.Instance.RemoveGameFileTag(gameFiles, tag);
-
-            DataCache.Instance.TagMapLookup.Refresh(new ITagData[] { tag });
-            UpdateTagTabData(tag.TagID);
-
+            // Update the current view 
             foreach (IGameFile gameFile in gameFiles)
                 GetCurrentViewControl().UpdateGameFile(gameFile);
 

--- a/DoomLauncher/Forms/MainForm_Init.cs
+++ b/DoomLauncher/Forms/MainForm_Init.cs
@@ -170,44 +170,37 @@ namespace DoomLauncher
             IGameFileView currentControl = GetCurrentViewControl();
             if (currentControl != null)
             {
-                List<ITagData> addTags = new List<ITagData>();
-                List<ITagData> removeTags = new List<ITagData>();
-
                 DataCache.Instance.UpdateTags();
 
-                foreach (var gameFile in SelectedItems(currentControl))
-                {
-                    if (gameFile.GameFileID.HasValue)
-                    {
-                        var gameFileTags = DataCache.Instance.TagMapLookup.GetTags(gameFile);
-                        var currentRemoveTags = DataCache.Instance.Tags.Where(x => gameFileTags.Any(y => y.TagID == x.TagID));
-                        var currentAddTags = DataCache.Instance.Tags.Except(currentRemoveTags);
-
-                        addTags = addTags.Union(currentAddTags).ToList();
-                        removeTags = removeTags.Union(currentRemoveTags).ToList();
-                    }
-                }
+                var selectedGameFiles = SelectedItems(currentControl);
+                var selectedGameFileTags = selectedGameFiles.SelectMany(DataCache.Instance.TagMapLookup.GetTags);
 
                 ToolStripMenuItem tagToolStrip = mnuLocal.Items.Cast<ToolStripItem>().FirstOrDefault(x => x.Text == "Tag") as ToolStripMenuItem;
-                ToolStripMenuItem removeTagToolStrip = mnuLocal.Items.Cast<ToolStripItem>().FirstOrDefault(x => x.Text == "Remove Tag") as ToolStripMenuItem;
 
                 if (tagToolStrip != null)
                 {
-                    BuildTagToolStrip(tagToolStrip, addTags, tagToolStripItem_Click);
-                    BuildTagToolStrip(removeTagToolStrip, removeTags, removeTagToolStripItem_Click);
+                    BuildTagToolStrip(tagToolStrip, selectedGameFileTags, tagToolStripItem_Click);
                 }
             }
         }
 
-        private void BuildTagToolStrip(ToolStripMenuItem tagToolStrip, IEnumerable<ITagData> tags, EventHandler handler)
+        private void BuildTagToolStrip(ToolStripMenuItem tagToolStrip, IEnumerable<ITagData> myTags, EventHandler handler)
         {
             while (tagToolStrip.DropDownItems.Count > 2)
                 tagToolStrip.DropDownItems.RemoveAt(tagToolStrip.DropDownItems.Count - 1);
 
-            foreach (ITagData tag in tags)
+            var allTags = DataCache.Instance.Tags;
+
+            foreach (ITagData tag in allTags)
             {
-                var item = tagToolStrip.DropDownItems.Add(tag.FavoriteName, null, handler);
-                item.Tag = tag.TagID;
+                var tagItem = new ToolStripMenuItem();
+                tagItem.Text = tag.FavoriteName;
+                tagItem.CheckOnClick = true;
+                tagItem.Checked = myTags.Any(t => t.TagID == tag.TagID);
+                tagItem.Click += handler;
+                tagItem.Tag = tag.TagID;
+
+                tagToolStrip.DropDownItems.Add(tagItem);
             }
         }
 

--- a/DoomLauncher/Stylize/CToolStripRenderer.cs
+++ b/DoomLauncher/Stylize/CToolStripRenderer.cs
@@ -16,7 +16,7 @@ namespace DoomLauncher
         protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
         {
             Color color = e.Item.Selected ? ColorTheme.Current.HighlightText : ColorTheme.Current.Text;
-            e.Graphics.DrawString(e.Item.Text, e.Item.Font, new SolidBrush(color), new PointF(24, 2));
+            e.Graphics.DrawString(e.Item.Text, e.Item.Font, new SolidBrush(color), new PointF(34, 2));
         }
 
         protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)


### PR DESCRIPTION
Addressing #329 with a streamlined `Tag` submenu that combines the "Tag", "Remove Tag" and "Select Tag..." functionality, using inline toggle boxes. Thanks @Hyperlynx2 for the suggestion.

Handles multiple selected gamefiles by showing all of their tags as checked, even if some of the gamefiles don't have the tag. Subsequent toggles will apply or unapply the tag for all of the selected gamefiles. A more polished solution might be able to show some intermediate icon instead of a check in those cases, but I think this is good enough UX for a first cut. 

I had to adjust the style slightly, because the checkboxes were all smooshed into the writing with the existing custom style. 