### PR TITLE
Hexen image fix

### DIFF
--- a/DoomLauncher/DoomLauncher.csproj
+++ b/DoomLauncher/DoomLauncher.csproj
@@ -279,6 +279,7 @@
     <Compile Include="Handlers\Sync\GameInfoSyncAction.cs" />
     <Compile Include="Handlers\Sync\ISyncAction.cs" />
     <Compile Include="Handlers\Sync\IWadTitlesSyncAction.cs" />
+    <Compile Include="Handlers\Sync\KnownTitlesSyncAction.cs" />
     <Compile Include="Handlers\Sync\MapInfoUtil.cs" />
     <Compile Include="Handlers\Sync\MapStringSyncAction.cs" />
     <Compile Include="Handlers\Sync\StartupImageSyncAction.cs" />

--- a/DoomLauncher/Forms/MainForm_Sync.cs
+++ b/DoomLauncher/Forms/MainForm_Sync.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using WadReader;
 
 namespace DoomLauncher
 {
@@ -96,12 +95,13 @@ namespace DoomLauncher
                     new MapStringSyncAction(AppConfiguration.TempDirectory),
                     new GameInfoSyncAction(),
                     new StartupImageSyncAction(),
-                    new TitlePicSyncAction(DataCache.Instance.DefaultPalette, 
-                                            DataCache.Instance.HexenPalette, 
+                    new TitlePicSyncAction(DataCache.Instance.DefaultPalette,
+                                            DataCache.Instance.HexenPalette,
                                             DataCache.Instance.HereticPalette).OnlyIf(AppConfiguration.AutomaticallyPullTitlpic),
                     new Doom64TitlePicSyncAction(),
                     new IWadTitlesSyncAction(),
-                    new GameConfSyncAction(DataSourceAdapter)
+                    new GameConfSyncAction(DataSourceAdapter),
+                    new KnownTitlesSyncAction()
                 };
 
                 handler = new SyncLibraryHandler(DataSourceAdapter, DirectoryDataSourceAdapter, AppConfiguration, 

--- a/DoomLauncher/Handlers/Sync/KnownTitlesSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/KnownTitlesSyncAction.cs
@@ -1,0 +1,26 @@
+﻿using DoomLauncher.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DoomLauncher.Handlers.Sync
+{
+    public class KnownTitlesSyncAction : ISyncAction
+    {
+        public SyncResult ApplyToGameFile(IGameFile file, IArchiveReader reader, string[] mapInfoData)
+        {
+            var baseName = Path.GetFileNameWithoutExtension(file.FileName).ToLower();
+            
+            switch (baseName)
+            {
+                case "hexdd":
+                    file.Title = "Hexen: Deathkings of the Dark Citadel";
+                    break;
+            };
+            return SyncResult.EMPTY;
+        }
+    }
+}

--- a/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
@@ -14,7 +14,7 @@ namespace DoomLauncher.Handlers.Sync
     {
         private const string DoomTitlepicName = "TITLEPIC";
         private const string HereticHexenTitlepicName = "TITLE";
-        private readonly List<string> KnownHexenWads = new List<string>() { "hexdd", "hexen" };
+        private readonly HashSet<string> KnownHexenWads = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "hexdd", "hexen" };
         private static readonly Regex TitlePageRegex = new Regex(@"titlepage\s*=\s*""([^""]*)""");
         private readonly Palette m_doomPalette;
         private readonly Palette m_hexenPalette;
@@ -39,7 +39,7 @@ namespace DoomLauncher.Handlers.Sync
             {
                 if (TitlePicUtil.GetEntry(reader, HereticHexenTitlepicName, out entry))
                 {
-                    var baseName = Path.GetFileNameWithoutExtension(file.FileNameNoPath).ToLower();
+                    var baseName = Path.GetFileNameWithoutExtension(file.FileNameNoPath);
                     if (KnownHexenWads.Contains(baseName))
                         palette = m_hexenPalette;
                     else

--- a/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
@@ -1,8 +1,11 @@
 ﻿using DoomLauncher.Interfaces;
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
+using System.Windows.Documents;
 using WadReader;
 
 namespace DoomLauncher.Handlers.Sync
@@ -11,6 +14,7 @@ namespace DoomLauncher.Handlers.Sync
     {
         private const string DoomTitlepicName = "TITLEPIC";
         private const string HereticHexenTitlepicName = "TITLE";
+        private readonly List<string> KnownHexenWads = new List<string>() { "hexdd", "hexen" };
         private static readonly Regex TitlePageRegex = new Regex(@"titlepage\s*=\s*""([^""]*)""");
         private readonly Palette m_doomPalette;
         private readonly Palette m_hexenPalette;
@@ -35,7 +39,8 @@ namespace DoomLauncher.Handlers.Sync
             {
                 if (TitlePicUtil.GetEntry(reader, HereticHexenTitlepicName, out entry))
                 {
-                    if (Path.GetFileNameWithoutExtension(file.FileNameNoPath).Equals("hexdd", StringComparison.OrdinalIgnoreCase))
+                    var baseName = Path.GetFileNameWithoutExtension(file.FileNameNoPath).ToLower();
+                    if (KnownHexenWads.Contains(baseName))
                         palette = m_hexenPalette;
                     else
                         palette = m_hereticPalette;

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,8 @@
 # 3.8.1
 
 ## Features:
-
+- We can now properly render Heretic title images
+- Hexen: Deathkings of the Dark Citadel now has the correct title
 
 ## Bug Fixes:
+- Fixed broken thumbnail rendering for hexen.wad


### PR DESCRIPTION
Small bug fix for immediate merge. 

Our recent palette work broke Hexen.wad - this is fixed now. In addition, there is now a sync action that recognises "hexdd" and returns the correct title.