### PR TITLE
Map string fix

### DIFF
--- a/DoomLauncher/Archive/RecursiveArchiveReader.cs
+++ b/DoomLauncher/Archive/RecursiveArchiveReader.cs
@@ -5,7 +5,7 @@ namespace DoomLauncher.Archive
 {
     public class RecursiveArchiveReader : IArchiveReader
     {
-        private readonly IArchiveReader m_root;
+        public IArchiveReader Root { get; }
         private readonly Func<IArchiveEntry, IArchiveReader> m_getChildReader; // null return value means no children
 
         private delegate void DisposeMethod();
@@ -13,7 +13,7 @@ namespace DoomLauncher.Archive
 
         public RecursiveArchiveReader(IArchiveReader root, Func<IArchiveEntry, IArchiveReader> getChildReader) 
         {
-            m_root = root;
+            Root = root;
             m_getChildReader = getChildReader;
         }
 
@@ -24,7 +24,7 @@ namespace DoomLauncher.Archive
         {
             // Recursive enumerable, adapted from https://stackoverflow.com/a/30441479
             var stack = new Stack<IEnumerator<IArchiveEntry>>();
-            IEnumerator<IArchiveEntry> enumerator = m_root.Entries.GetEnumerator();
+            IEnumerator<IArchiveEntry> enumerator = Root.Entries.GetEnumerator();
 
             try
             {
@@ -69,11 +69,11 @@ namespace DoomLauncher.Archive
             }
         }
 
-        public bool EntriesHaveExtensions => m_root.EntriesHaveExtensions;
+        public bool EntriesHaveExtensions => Root.EntriesHaveExtensions;
 
         public void Dispose()
         {
-            m_root.Dispose();
+            Root.Dispose();
             Disposing?.Invoke();
         }
     }

--- a/DoomLauncher/Handlers/Sync/MapStringSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/MapStringSyncAction.cs
@@ -1,7 +1,8 @@
-﻿using System.IO;
+﻿using DoomLauncher.Archive;
 using DoomLauncher.Interfaces;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -96,23 +97,24 @@ namespace DoomLauncher.Handlers.Sync
             return matches.Cast<Match>().Select(x => x.Value.Trim().Substring(3).Trim()).ToList();
         }
 
-        private List<string> MapStringFromGameFileWads(IArchiveReader reader)
+        private List<string> MapStringFromGameFileWads(IArchiveReader reader) =>
+            GetIWadFilenames(reader).SelectMany(Util.GetMapStringFromWad).ToList();
+
+        private List<string> GetIWadFilenames(IArchiveReader reader)
         {
-            List<string> maps = new List<string>();
             if (reader is WadArchiveReader wadArchive)
             {
-                maps.AddRange(Util.GetMapStringFromWad(wadArchive.Filename));
+                return new List<string>() { wadArchive.Filename };
+            }
+            else if (reader is RecursiveArchiveReader recursiveReader && recursiveReader.Root is WadArchiveReader wadArchive2)
+            {
+                return new List<string>() { wadArchive2.Filename };
             }
             else
             {
                 IEnumerable<IArchiveEntry> wadEntries = GetEntriesByExtension(reader, ".wad");
-                foreach (IArchiveEntry entry in wadEntries)
-                {
-                    string extractFile = Util.ExtractTempFile(m_tempDirectory.GetFullPath(), entry);
-                    maps.AddRange(Util.GetMapStringFromWad(extractFile));
-                }
+                return wadEntries.Select(entry => Util.ExtractTempFile(m_tempDirectory.GetFullPath(), entry)).ToList();
             }
-            return maps;
         }
 
         private static string[] GetArchiveEntryData(params IArchiveEntry[] entries)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,3 +6,4 @@
 
 ## Bug Fixes:
 - Fixed broken thumbnail rendering for hexen.wad
+- Map string was not being generated for WADs directly dragged into DoomLauncher on Unmanaged mode


### PR DESCRIPTION
- Addresses #349 reported by [@TouchFuzzyGH](https://github.com/TouchfuzzyGH) - map strings were not being generated for WADs dragged into the app on Unmanaged mode.
- This was caused by the introduction of `RecursiveArchiveReader`, which broke code that was relying on being able to directly typecase `WadArchiveReader`.
- Fixed by also typecasing the `RecursiveArchiveReader` root reader as `WadArchiveReader`.
- This whole mechanism of typecasing IArchiveReaders is pretty gross, but I don't have a better idea for the time being.
- Ideally we would have a test to isolate the bug and prove the fix, but it's too hard writing tests for `MapStringSyncAction` imho. I think we will have to kick this class in the butt to make it more testable at some point.

fixes #349 