### PR TITLE
[3.8.1] Resync ux

### DIFF
--- a/DoomLauncher/Controls/GameFileTileViewControl.cs
+++ b/DoomLauncher/Controls/GameFileTileViewControl.cs
@@ -208,7 +208,7 @@ namespace DoomLauncher
         private void Instance_TilesRecreated(object sender, EventArgs e)
         {
             m_tilesRecreated = true;
-            pagingControl.Init(m_gameFiles.Count, GameFileTileManager.Instance.MaxItems);
+            pagingControl.Init(m_gameFiles.Count, GameFileTileManager.Instance.MaxItems, 0);
 
             SetItemsPerPage(GameFileTileManager.Instance.MaxItems);
 
@@ -424,7 +424,6 @@ namespace DoomLauncher
             ClearHover();
             ClearDisplayLabel();
 
-            bool update = false;
             int saveIndex = pagingControl.PageIndex;
 
             if (gameFiles == null)
@@ -433,28 +432,16 @@ namespace DoomLauncher
             }
             else
             {
-                var diff = m_gameFiles.Except(gameFiles);
-                // Basically a hack for when deleting a single item to keep the current page
-                update = diff.Count() == 1;
                 m_gameFiles = gameFiles.ToList();
             }
 
-            pagingControl.Init(m_gameFiles.Count, GameFileTileManager.Instance.MaxItems);
+            pagingControl.Init(m_gameFiles.Count, GameFileTileManager.Instance.MaxItems, saveIndex);
 
             if (!m_visible)
                 return;
 
-            if (update)
-            {
-                if (!pagingControl.SetPageIndex(saveIndex))
-                    SetPageData(saveIndex, false);
-                SetDefaultSelection();
-            }
-            else
-            {
-                SetPageData(0, true);
-                SetDefaultSelection();
-            }
+            SetPageData(saveIndex, false);
+            SetDefaultSelection();
         }
 
         private void ClearDisplayLabel()

--- a/DoomLauncher/Controls/PagingControl.cs
+++ b/DoomLauncher/Controls/PagingControl.cs
@@ -34,10 +34,7 @@ namespace DoomLauncher
                 PageIndex = 0;
         }
 
-        public bool SetPageIndex(int index) => 
-            SetPageIndex(index, false);
-
-        private bool SetPageIndex(int index, bool publishEvent)
+        private void SetPageIndex(int index, bool publishEvent)
         {
             if (index < 0)
                 index = 0;
@@ -47,14 +44,12 @@ namespace DoomLauncher
             lblPage.Text = (index + 1).ToString();
 
             if (PageIndex == index)
-                return false;
+                return;
 
             PageIndex = index;
 
             if (publishEvent)
                 PageIndexChanged?.Invoke(this, EventArgs.Empty);
-
-            return true;
         }
 
         private void BtnNext_Click(object sender, EventArgs e)

--- a/DoomLauncher/Controls/PagingControl.cs
+++ b/DoomLauncher/Controls/PagingControl.cs
@@ -16,7 +16,7 @@ namespace DoomLauncher
             Stylizer.StylizeControl(this, DesignMode);
         }
 
-        public void Init(int records, int recordsPerPage)
+        public void Init(int records, int recordsPerPage, int initialPage)
         {
             Pages = records / recordsPerPage;
             if (records % recordsPerPage != 0)
@@ -28,12 +28,16 @@ namespace DoomLauncher
             tblMain.ColumnStyles[3].Width = size.Width;
             tblMain.ColumnStyles[5].Width = size.Width;
 
-            PageIndex = 0;
             if (Pages > 0)
-                SetPageIndex(0);
+                SetPageIndex(initialPage, false);
+            else
+                PageIndex = 0;
         }
 
-        public bool SetPageIndex(int index)
+        public bool SetPageIndex(int index) => 
+            SetPageIndex(index, false);
+
+        private bool SetPageIndex(int index, bool publishEvent)
         {
             if (index < 0)
                 index = 0;
@@ -47,28 +51,30 @@ namespace DoomLauncher
 
             PageIndex = index;
 
-            PageIndexChanged?.Invoke(this, EventArgs.Empty);
+            if (publishEvent)
+                PageIndexChanged?.Invoke(this, EventArgs.Empty);
+
             return true;
         }
 
         private void BtnNext_Click(object sender, EventArgs e)
         {
-            SetPageIndex(PageIndex + 1);
+            SetPageIndex(PageIndex + 1, true);
         }
 
         private void BtnPrev_Click(object sender, EventArgs e)
         {
-            SetPageIndex(PageIndex - 1);
+            SetPageIndex(PageIndex - 1, true);
         }
 
         private void BtnFirst_Click(object sender, EventArgs e)
         {
-            SetPageIndex(0);
+            SetPageIndex(0, true);
         }
 
         private void BtnLast_Click(object sender, EventArgs e)
         {
-            SetPageIndex(Pages - 1);
+            SetPageIndex(Pages - 1, true);
         }
     }
 }

--- a/DoomLauncher/Forms/MainForm.cs
+++ b/DoomLauncher/Forms/MainForm.cs
@@ -76,7 +76,7 @@ namespace DoomLauncher
             copyProgressBar.Cancelled += m_progressBarFormCopy_Cancelled;
 
             m_progressBars[ProgressBarType.Copy] = copyProgressBar;
-            m_progressBars[ProgressBarType.Sync] = CreateProgressBar("Syncing...", ProgressBarStyle.Marquee, false);
+            m_progressBars[ProgressBarType.Sync] = CreateProgressBar("Syncing...", ProgressBarStyle.Continuous, false);
             m_progressBars[ProgressBarType.Update] = CreateProgressBar("Updating...", ProgressBarStyle.Marquee, false);
             m_progressBars[ProgressBarType.Delete] = CreateProgressBar("Deleting...", ProgressBarStyle.Marquee, false);
             m_progressBars[ProgressBarType.Search] = CreateProgressBar("Searching...", ProgressBarStyle.Marquee, false);

--- a/DoomLauncher/Forms/MainForm_Sync.cs
+++ b/DoomLauncher/Forms/MainForm_Sync.cs
@@ -15,7 +15,8 @@ namespace DoomLauncher
     {
         private async Task<SyncResult> SyncLocalDatabase(string[] fileNames, FileManagement fileManagement, bool updateViews, ITagData tag = null)
         {
-            ProgressBarStart(ProgressBarType.Sync);
+            var pg = ProgressBarStart(ProgressBarType.Sync);
+            pg.Text = $"Syncing {fileNames.Count()} files...";
             SyncResult syncResult =  await Task.Run(() => ExecuteSyncHandler(fileNames, fileManagement, tag));
             ProgressBarEnd(ProgressBarType.Sync);
             SyncLocalDatabaseComplete(syncResult, updateViews);


### PR DESCRIPTION
Addresses #358, improving the user experience of resyncing. 

- It now shows a proper progress bar
- Respects the current selection and page

## Notes 
- To make it respect the current page, I had to make it so that the `PagingControl` only publishes `PageIndexChanged` events when it is driven by user interaction. When it is driven by code, then it assumes that the calling code already knows what it is doing.
- I deleted some code using an `update` variable in `GameFileTileViewControl`, because the logic looked wrong, and it didn't seem necessary. I'd like to call attention to this in case I've misjudged the intent of the code.
- I have manually tested this by deleting game files - it seems to still rebalance the pages fine. 
- I had a crack at fixing the stuck wait cursor on `tblMain` inside `TagSelectControl`, but that is a really weird one - it's harder than it looks. I've tried a bunch of different solutions suggested by Copilot and none of them seem to work. Googling/StackOverflow wasn't much help either.