### PR TITLE
[3.8.1] Fixed Hexen titlepics so that they are not hardcoded

### DIFF
--- a/DoomLauncher/DataSources/GameFile.cs
+++ b/DoomLauncher/DataSources/GameFile.cs
@@ -24,6 +24,7 @@ namespace DoomLauncher.DataSources
         public int? GameFileID { get; set; }
         public string FullFileName { get; set; }
         public virtual string FileName { get; set; }
+        public string FileNameBase => Path.GetFileNameWithoutExtension(FileName);
         public string FileNameNoPath => Path.GetFileName(FileName);
         public virtual string LastDirectory => GetLastDirectory(FileName);
         public virtual string Title { get; set; }

--- a/DoomLauncher/DataSources/IWadData.cs
+++ b/DoomLauncher/DataSources/IWadData.cs
@@ -1,4 +1,5 @@
 ﻿using DoomLauncher.Interfaces;
+using System.IO;
 
 namespace DoomLauncher
 {
@@ -7,6 +8,9 @@ namespace DoomLauncher
         public int IWadID { get; set; }
         public string Name { get; set; }
         public string FileName { get; set; }
+
+        public string FileNameBase => Path.GetFileNameWithoutExtension(FileName);
+
         public int? GameFileID { get; set; }
 
         public override bool Equals(object obj)

--- a/DoomLauncher/DoomLauncher.csproj
+++ b/DoomLauncher/DoomLauncher.csproj
@@ -279,7 +279,7 @@
     <Compile Include="Handlers\Sync\GameInfoSyncAction.cs" />
     <Compile Include="Handlers\Sync\ISyncAction.cs" />
     <Compile Include="Handlers\Sync\IWadTitlesSyncAction.cs" />
-    <Compile Include="Handlers\Sync\KnownTitlesSyncAction.cs" />
+    <Compile Include="Handlers\Sync\KnownWadsSyncAction.cs" />
     <Compile Include="Handlers\Sync\MapInfoUtil.cs" />
     <Compile Include="Handlers\Sync\MapStringSyncAction.cs" />
     <Compile Include="Handlers\Sync\StartupImageSyncAction.cs" />

--- a/DoomLauncher/Forms/MainForm_Sync.cs
+++ b/DoomLauncher/Forms/MainForm_Sync.cs
@@ -96,13 +96,14 @@ namespace DoomLauncher
                     new MapStringSyncAction(AppConfiguration.TempDirectory),
                     new GameInfoSyncAction(),
                     new StartupImageSyncAction(),
-                    new TitlePicSyncAction(DataCache.Instance.DefaultPalette,
+                    new TitlePicSyncAction(DataSourceAdapter, 
+                                            DataCache.Instance.DefaultPalette,
                                             DataCache.Instance.HexenPalette,
                                             DataCache.Instance.HereticPalette).OnlyIf(AppConfiguration.AutomaticallyPullTitlpic),
                     new Doom64TitlePicSyncAction(),
                     new IWadTitlesSyncAction(),
                     new GameConfSyncAction(DataSourceAdapter),
-                    new KnownTitlesSyncAction()
+                    new KnownWadsSyncAction(DataSourceAdapter)
                 };
 
                 handler = new SyncLibraryHandler(DataSourceAdapter, DirectoryDataSourceAdapter, AppConfiguration, 

--- a/DoomLauncher/Handlers/Sync/GameConfSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/GameConfSyncAction.cs
@@ -53,7 +53,7 @@ namespace DoomLauncher.Handlers.Sync
                             gameFile.IWadID = iwadFile.IWadID;
                     }
                 }
-                catch (Exception ex)
+                catch
                 {
 
                 }

--- a/DoomLauncher/Handlers/Sync/KnownWadsSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/KnownWadsSyncAction.cs
@@ -1,23 +1,26 @@
 ﻿using DoomLauncher.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DoomLauncher.Handlers.Sync
 {
-    public class KnownTitlesSyncAction : ISyncAction
+    public class KnownWadsSyncAction : ISyncAction
     {
+        private readonly IDataSourceAdapter m_database;
+
+        public KnownWadsSyncAction(IDataSourceAdapter database)
+        {
+            m_database = database;
+        }
+
         public SyncResult ApplyToGameFile(IGameFile file, IArchiveReader reader, string[] mapInfoData)
         {
-            var baseName = Path.GetFileNameWithoutExtension(file.FileName).ToLower();
+            var baseName = file.FileNameBase.ToLower();
             
             switch (baseName)
             {
                 case "hexdd":
                     file.Title = "Hexen: Deathkings of the Dark Citadel";
+                    file.IWadID = m_database.GetIWads().FirstOrDefault(iwad => iwad.FileNameBase.Equals("hexen"))?.IWadID;
                     break;
             };
             return SyncResult.EMPTY;

--- a/DoomLauncher/Handlers/Sync/KnownWadsSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/KnownWadsSyncAction.cs
@@ -1,4 +1,5 @@
 ﻿using DoomLauncher.Interfaces;
+using System;
 using System.Linq;
 
 namespace DoomLauncher.Handlers.Sync
@@ -20,7 +21,7 @@ namespace DoomLauncher.Handlers.Sync
             {
                 case "hexdd":
                     file.Title = "Hexen: Deathkings of the Dark Citadel";
-                    file.IWadID = m_database.GetIWads().FirstOrDefault(iwad => iwad.FileNameBase.Equals("hexen"))?.IWadID;
+                    file.IWadID = m_database.GetIWads().FirstOrDefault(iwad => iwad.FileNameBase.Equals("hexen", StringComparison.OrdinalIgnoreCase))?.IWadID;
                     break;
             };
             return SyncResult.EMPTY;

--- a/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
@@ -13,7 +13,6 @@ namespace DoomLauncher.Handlers.Sync
     {
         private const string DoomTitlepicName = "TITLEPIC";
         private const string HereticHexenTitlepicName = "TITLE";
-        private readonly HashSet<string> KnownHexenWads = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "hexdd", "hexen" };
         private static readonly Regex TitlePageRegex = new Regex(@"titlepage\s*=\s*""([^""]*)""");
         private readonly Palette m_doomPalette;
         private readonly Palette m_hexenPalette;

--- a/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
@@ -5,7 +5,6 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Windows.Documents;
 using WadReader;
 
 namespace DoomLauncher.Handlers.Sync
@@ -19,12 +18,14 @@ namespace DoomLauncher.Handlers.Sync
         private readonly Palette m_doomPalette;
         private readonly Palette m_hexenPalette;
         private readonly Palette m_hereticPalette;
+        private readonly IDataSourceAdapter m_database;
 
-        public TitlePicSyncAction(Palette doomPalette, Palette hexenPalette, Palette hereticPalette)
+        public TitlePicSyncAction(IDataSourceAdapter database, Palette doomPalette, Palette hexenPalette, Palette hereticPalette)
         {
             m_doomPalette = doomPalette;
             m_hexenPalette = hexenPalette;
             m_hereticPalette = hereticPalette;
+            m_database = database;
         }
 
         public SyncResult ApplyToGameFile(IGameFile file, IArchiveReader reader, string[] mapInfoData)
@@ -39,8 +40,9 @@ namespace DoomLauncher.Handlers.Sync
             {
                 if (TitlePicUtil.GetEntry(reader, HereticHexenTitlepicName, out entry))
                 {
-                    var baseName = Path.GetFileNameWithoutExtension(file.FileNameNoPath);
-                    if (KnownHexenWads.Contains(baseName))
+                    var iwadFileName = m_database.GetIWads().FirstOrDefault(iw => iw.IWadID == file.IWadID)?.FileNameBase;
+
+                    if (iwadFileName != null && iwadFileName.ToLower().Equals("hexen"))
                         palette = m_hexenPalette;
                     else
                         palette = m_hereticPalette;

--- a/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
@@ -42,7 +42,7 @@ namespace DoomLauncher.Handlers.Sync
                 {
                     var iwadFileName = m_database.GetIWads().FirstOrDefault(iw => iw.IWadID == file.IWadID)?.FileNameBase;
 
-                    if (iwadFileName != null && iwadFileName.ToLower().Equals("hexen"))
+                    if (iwadFileName != null && iwadFileName.Equals("hexen", StringComparison.OrdinalIgnoreCase))
                         palette = m_hexenPalette;
                     else
                         palette = m_hereticPalette;

--- a/DoomLauncher/Interfaces/IGameFile.cs
+++ b/DoomLauncher/Interfaces/IGameFile.cs
@@ -6,6 +6,7 @@ namespace DoomLauncher.Interfaces
     {
         int? GameFileID { get; set; }
         string FileName { get; set; }
+        string FileNameBase { get; }
         string FileNameNoPath { get; }
         string LastDirectory { get; }
         string Title { get; set; }

--- a/DoomLauncher/Interfaces/IIWadData.cs
+++ b/DoomLauncher/Interfaces/IIWadData.cs
@@ -5,6 +5,9 @@
         int IWadID { get; set; }
         string Name { get; set; }
         string FileName { get; set; }
+
+        string FileNameBase { get; }
+
         int? GameFileID { get; set; }
     }
 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,7 +4,9 @@
 - We can now properly render Heretic title images
 - Hexen: Deathkings of the Dark Citadel now has the correct title
 - Autoloader will pick up Heretic + Hexen original wads with Hexen: Deathkings of the Dark Citadel
+- Resync progress bar now shows progress
 
 ## Bug Fixes:
-- Fixed broken thumbnail rendering for hexen.wad
+- Fixed broken thumbnail rendering for hexen.wad and other Hexen wads
 - Map string was not being generated for WADs directly dragged into DoomLauncher on Unmanaged mode
+- Resyncing keeps the current selection and page, instead of jumping back to the first file on page 1

--- a/UnitTest/Tests/TestKnownWadsSyncAction.cs
+++ b/UnitTest/Tests/TestKnownWadsSyncAction.cs
@@ -1,0 +1,83 @@
+﻿using DoomLauncher;
+using DoomLauncher.DataSources;
+using DoomLauncher.Handlers.Sync;
+using DoomLauncher.Interfaces;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace UnitTest.Tests
+{
+    [TestClass]
+    public class TestKnownWadsSyncAction
+    {
+        IDataSourceAdapter database;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            database = TestUtil.CreateAdapter();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            var dataAccess = ((DbDataSourceAdapter)database).DataAccess;
+            dataAccess.ExecuteNonQuery("delete from IWads");
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_DoesNothingToUnknownGameFile()
+        {
+            var action = new KnownWadsSyncAction(database);
+
+            var gameFile = new GameFile()
+            {
+                FileName = "Unknown.zip",
+                Title = "MyTitle"
+            };
+
+            action.ApplyToGameFile(gameFile, null, null);
+
+            Assert.AreEqual("MyTitle", gameFile.Title);
+            Assert.IsNull(gameFile.IWadID);
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_SetsTheTitleForHexDD()
+        {
+            var action = new KnownWadsSyncAction(database);
+
+            var gameFile = new GameFile()
+            {
+                FileName = "hexdd.zip",
+                Title = "Replace me"
+            };
+
+            action.ApplyToGameFile(gameFile, null, null);
+
+            Assert.AreEqual("Hexen: Deathkings of the Dark Citadel", gameFile.Title);
+        }
+
+        [TestMethod]
+        public void ApplyToGameFile_SetsTheHexenIWadForHexDD()
+        {
+            var action = new KnownWadsSyncAction(database);
+
+            IIWadData hexenIwad = new IWadData() { FileName = "hexen.wad" };
+            database.InsertIWad(hexenIwad);
+            hexenIwad = database.GetIWads().FirstOrDefault(iwad => iwad.FileNameBase.Equals("hexen"));
+            Assert.IsNotNull(hexenIwad);
+            Assert.IsNotNull(hexenIwad.IWadID);
+
+            var gameFile = new GameFile()
+            {
+                FileName = "hexdd.zip",
+                Title = "Replace me"
+            };
+
+            action.ApplyToGameFile(gameFile, null, null);
+
+            Assert.AreEqual(hexenIwad.IWadID, gameFile.IWadID);
+        }
+    }
+}

--- a/UnitTest/Tests/TestSyncLibraryHandler.cs
+++ b/UnitTest/Tests/TestSyncLibraryHandler.cs
@@ -434,7 +434,7 @@ namespace UnitTest.Tests
             };
 
             if (pullTitlepic)
-                syncActions.Add(new TitlePicSyncAction(DataCache.Instance.DefaultPalette, DataCache.Instance.HexenPalette, DataCache.Instance.HereticPalette));
+                syncActions.Add(new TitlePicSyncAction(database, DataCache.Instance.DefaultPalette, DataCache.Instance.HexenPalette, DataCache.Instance.HereticPalette));
 
             return new SyncLibraryHandler(database, CreateDirectoryAdapater(), directories, fileManagement, syncActions);
         }

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Tests\TestGameConfSyncAction.cs" />
     <Compile Include="Tests\TestGameInfoSyncAction.cs" />
     <Compile Include="Tests\TestIWadTitlesSyncAction.cs" />
+    <Compile Include="Tests\TestKnownWadsSyncAction.cs" />
     <Compile Include="Tests\TestMapStringSyncAction.cs" />
     <Compile Include="Tests\TestRecursiveArchiveReader.cs" />
     <Compile Include="Tests\TestGameStoreFiles.cs" />


### PR DESCRIPTION
- Fixed Hexen titlepics so that they are not hardcoded and can work with any Hexen wad.
- Adding a `FileNameBase` field to `IGameFile` and `IIWadData`, because we seem to be using `Path.GetFileNameWithoutExtension` a lot.
- `KnownTitlesSyncAction` is now `KnownWadsSyncAction`, so it now autofills the IWadID for "hexdd". This means we don't have to hardcode it in the `TitlePicSyncAction`