### PR TITLE
4:3 thumbnails

### DIFF
--- a/DoomLauncher/Controls/GameFileTile.cs
+++ b/DoomLauncher/Controls/GameFileTile.cs
@@ -60,7 +60,7 @@ namespace DoomLauncher
             Paint += GameFileTile_Paint;
         }
 
-        public static int GetImageHeight(int imageWidth) => (int)(imageWidth / (16.0 / 9.0));
+        public static int GetImageHeight(int imageWidth) => (int)(imageWidth / (4.0 / 3.0));
 
         public int GetStandardHeight(DpiScale dpiScale)
         {

--- a/DoomLauncher/DoomLauncher.csproj
+++ b/DoomLauncher/DoomLauncher.csproj
@@ -278,6 +278,7 @@
     <Compile Include="Handlers\Files\GameFileImageHandler.cs" />
     <Compile Include="Handlers\Files\IFileHandler.cs" />
     <Compile Include="Handlers\Files\LegacyTitlePicMigration.cs" />
+    <Compile Include="Handlers\Files\ThumbnailImages.cs" />
     <Compile Include="Handlers\Sync\StartupImageSyncAction.cs" />
     <Compile Include="Handlers\Sync\Doom64TitlePicSyncAction.cs" />
     <Compile Include="Handlers\Sync\GameConfSyncAction.cs" />

--- a/DoomLauncher/Forms/MainForm_Sync.cs
+++ b/DoomLauncher/Forms/MainForm_Sync.cs
@@ -156,7 +156,10 @@ namespace DoomLauncher
             {
                 // Get the titlepic as a bitmap in memory from a lump in the wad
                 if (!syncResult.GetTitlePic(gameFile, out Image image))
+                {
+                    gameFileImageHandler.UpdateImages(gameFile);
                     continue;
+                }
 
                 // Force the image to the right aspect ratio
                 image = image.ScaleDoomImage();

--- a/DoomLauncher/Handlers/Files/GameFileImageHandler.cs
+++ b/DoomLauncher/Handlers/Files/GameFileImageHandler.cs
@@ -1,4 +1,5 @@
-﻿using DoomLauncher.Interfaces;
+﻿using DoomLauncher.Handlers.Files;
+using DoomLauncher.Interfaces;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -138,7 +139,7 @@ namespace DoomLauncher.Handlers
             var parentFile = m_fileHandler.GetFullFileName(parent.FileTypeID, parent.FileName);
             using (Image image = Image.FromFile(parentFile))
             {
-                using (Image thumb = image.FixedSize(THUMBNAIL_SIZE, GameFileTile.GetImageHeight(THUMBNAIL_SIZE), Color.Black))
+                using (Image thumb = image.CreateStandardizedThumbnail(THUMBNAIL_SIZE, GameFileTile.GetImageHeight(THUMBNAIL_SIZE), gameFile))
                 {
                     return m_fileHandler.InsertAndSave(gameFile, FileType.Thumbnail, thumb, "png", file =>
                     {

--- a/DoomLauncher/Handlers/Files/ThumbnailImages.cs
+++ b/DoomLauncher/Handlers/Files/ThumbnailImages.cs
@@ -1,0 +1,150 @@
+﻿using DoomLauncher.DataSources;
+using DoomLauncher.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.Windows.Documents;
+using System.Windows.Navigation;
+
+namespace DoomLauncher.Handlers.Files
+{
+    public static class ThumbnailImages
+    {
+        // Adapted from ImageExtensions.FixedSize. Needs to be separate, because we are slowing down this method
+        // with fancier image processing, with the intention of it being called one time and subsequently cached on disk. 
+        // However, FixedSize gets cosntantly called all over the place at runtime for all kinds of workflows, and
+        // making it take longer has a devastating impact on application performance.
+        public static Image CreateStandardizedThumbnail(this Image imgPhoto, int width, int height, IGameFile gameFile)
+        {
+            int sourceWidth = imgPhoto.Width;
+            int sourceHeight = imgPhoto.Height;
+            int sourceX = 0;
+            int sourceY = 0;
+            int destX = 0;
+            int destY = 0;
+            int blurredSourceWidth = sourceWidth;
+            int blurredSourceHeight = sourceHeight;
+            int blurredSourceX = sourceX;
+            int blurredSourceY = sourceY;
+
+            float aspectRatio = width / (float)height;
+
+            float scalingPercent;
+            float scalingPercentW = width / (float)sourceWidth;
+            float scalingPercentH = height / (float)sourceHeight;
+
+            if (scalingPercentH < scalingPercentW) // Too tall, pillarbox
+            {
+                scalingPercent = scalingPercentH;
+                destX = Convert.ToInt16((width - (sourceWidth * scalingPercent)) / 2);
+                blurredSourceHeight = Convert.ToInt16(sourceHeight / aspectRatio);
+                blurredSourceY = sourceHeight / 2 - blurredSourceHeight / 2;
+            }
+            else // Too wide, letterbox
+            {
+                scalingPercent = scalingPercentW;
+                destY = Convert.ToInt16((height - (sourceHeight * scalingPercent)) / 2);
+                blurredSourceWidth = Convert.ToInt16(sourceWidth / aspectRatio);
+                blurredSourceX = sourceWidth / 2 - blurredSourceWidth / 2;
+
+            }
+
+            int destWidth = (int)(sourceWidth * scalingPercent);
+            int destHeight = (int)(sourceHeight * scalingPercent);
+
+            Bitmap bmPhoto = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
+            bmPhoto.SetResolution(imgPhoto.HorizontalResolution, imgPhoto.VerticalResolution);
+
+            Graphics grPhoto = Graphics.FromImage(bmPhoto);
+            grPhoto.InterpolationMode = InterpolationMode.HighQualityBicubic;
+
+            // Doom64 images seem to be sometimes transparent, and not 
+            // designed to look good in 4:3 mode.
+            if (gameFile.IsDoom64)
+            {
+                grPhoto.Clear(Color.Black);
+                grPhoto.DrawImage(imgPhoto,
+                    destRect: new Rectangle(destX, destY, destWidth, destHeight),
+                    srcRect: new Rectangle(sourceX, sourceY, sourceWidth, sourceHeight),
+                    GraphicsUnit.Pixel);
+            }
+            else
+            {
+                // The blurred one
+                grPhoto.DrawImage(imgPhoto,
+                    destRect: new Rectangle(0, 0, width, height),
+                    srcRect: new Rectangle(blurredSourceX, blurredSourceY, blurredSourceWidth, blurredSourceHeight),
+                    GraphicsUnit.Pixel);
+
+                // If it is a wide image, don't blur the enlarged space-filling image;
+                // we'll take that one as-is, and ignore the scaled-to-fit image. Wide
+                // titlepic images tend to be designed to fit in 4:3.
+                bool isWide = scalingPercentW < scalingPercentH;
+                if (!isWide)
+                {
+                    bmPhoto = Blur(bmPhoto, new Rectangle(0, 0, width, height), 8);
+
+                    grPhoto = Graphics.FromImage(bmPhoto);
+
+                    // The real one
+                    grPhoto.DrawImage(imgPhoto,
+                        destRect: new Rectangle(destX, destY, destWidth, destHeight),
+                        srcRect: new Rectangle(sourceX, sourceY, sourceWidth, sourceHeight),
+                        GraphicsUnit.Pixel);
+                }
+            }
+
+            grPhoto.Dispose();
+            return bmPhoto;
+        }
+
+        private static Bitmap Blur(Bitmap image, Rectangle rectangle, Int32 blurSize)
+        {
+            Bitmap blurred = new Bitmap(image.Width, image.Height);
+
+            // make an exact copy of the bitmap provided
+            using (Graphics graphics = Graphics.FromImage(blurred))
+                graphics.DrawImage(image, new Rectangle(0, 0, image.Width, image.Height),
+                    new Rectangle(0, 0, image.Width, image.Height), GraphicsUnit.Pixel);
+
+            // look at every pixel in the blur rectangle
+            for (int xx = rectangle.X; xx < rectangle.X + rectangle.Width; xx++)
+            {
+                for (int yy = rectangle.Y; yy < rectangle.Y + rectangle.Height; yy++)
+                {
+                    int avgR = 0, avgG = 0, avgB = 0;
+                    int blurPixelCount = 0;
+
+                    // average the color of the red, green and blue for each pixel in the
+                    // blur size while making sure you don't go outside the image bounds
+                    for (int x = xx; (x < xx + blurSize && x < image.Width); x++)
+                    {
+                        for (int y = yy; (y < yy + blurSize && y < image.Height); y++)
+                        {
+                            Color pixel = blurred.GetPixel(x, y);
+
+                            avgR += pixel.R;
+                            avgG += pixel.G;
+                            avgB += pixel.B;
+
+                            blurPixelCount++;
+                        }
+                    }
+
+                    avgR = avgR / blurPixelCount;
+                    avgG = avgG / blurPixelCount;
+                    avgB = avgB / blurPixelCount;
+
+                    // now that we know the average for the blur size, set each pixel to that color
+                    for (int x = xx; x < xx + blurSize && x < image.Width && x < rectangle.Width; x++)
+                        for (int y = yy; y < yy + blurSize && y < image.Height && y < rectangle.Height; y++)
+                            blurred.SetPixel(x, y, Color.FromArgb(avgR, avgG, avgB));
+                }
+            }
+
+            return blurred;
+        }
+    }
+}

--- a/DoomLauncher/Handlers/Files/ThumbnailImages.cs
+++ b/DoomLauncher/Handlers/Files/ThumbnailImages.cs
@@ -24,10 +24,10 @@ namespace DoomLauncher.Handlers.Files
             int sourceY = 0;
             int destX = 0;
             int destY = 0;
-            int blurredSourceWidth = sourceWidth;
-            int blurredSourceHeight = sourceHeight;
-            int blurredSourceX = sourceX;
-            int blurredSourceY = sourceY;
+            int spaceFillingSourceWidth = sourceWidth;
+            int spaceFillingSourceHeight = sourceHeight;
+            int spaceFillingSourceX = sourceX;
+            int spaceFillingSourceY = sourceY;
 
             float aspectRatio = width / (float)height;
 
@@ -39,15 +39,15 @@ namespace DoomLauncher.Handlers.Files
             {
                 scalingPercent = scalingPercentH;
                 destX = Convert.ToInt16((width - (sourceWidth * scalingPercent)) / 2);
-                blurredSourceHeight = Convert.ToInt16(sourceHeight / aspectRatio);
-                blurredSourceY = sourceHeight / 2 - blurredSourceHeight / 2;
+                spaceFillingSourceHeight = Convert.ToInt16(sourceHeight / aspectRatio);
+                spaceFillingSourceY = sourceHeight / 2 - spaceFillingSourceHeight / 2;
             }
             else // Too wide, letterbox
             {
                 scalingPercent = scalingPercentW;
                 destY = Convert.ToInt16((height - (sourceHeight * scalingPercent)) / 2);
-                blurredSourceWidth = Convert.ToInt16(sourceWidth / aspectRatio);
-                blurredSourceX = sourceWidth / 2 - blurredSourceWidth / 2;
+                spaceFillingSourceWidth = Convert.ToInt16(sourceWidth / aspectRatio);
+                spaceFillingSourceX = sourceWidth / 2 - spaceFillingSourceWidth / 2;
 
             }
 
@@ -59,92 +59,29 @@ namespace DoomLauncher.Handlers.Files
 
             Graphics grPhoto = Graphics.FromImage(bmPhoto);
             grPhoto.InterpolationMode = InterpolationMode.HighQualityBicubic;
+            grPhoto.Clear(Color.Black);
 
-            // Doom64 images seem to be sometimes transparent, and not 
-            // designed to look good in 4:3 mode.
-            if (gameFile.IsDoom64)
+            // Already the right ratio OR Doom64, just draw it.
+            // (Doom64 images tend to look better like this)
+            if (gameFile.IsDoom64 || scalingPercentW == scalingPercentH)
             {
-                grPhoto.Clear(Color.Black);
+                
                 grPhoto.DrawImage(imgPhoto,
-                    destRect: new Rectangle(destX, destY, destWidth, destHeight),
-                    srcRect: new Rectangle(sourceX, sourceY, sourceWidth, sourceHeight),
-                    GraphicsUnit.Pixel);
+                destRect: new Rectangle(destX, destY, destWidth, destHeight),
+                srcRect: new Rectangle(sourceX, sourceY, sourceWidth, sourceHeight),
+                GraphicsUnit.Pixel);
             }
+            // It's the wrong ratio, fill the space and truncate
             else
             {
-                // The blurred one
                 grPhoto.DrawImage(imgPhoto,
                     destRect: new Rectangle(0, 0, width, height),
-                    srcRect: new Rectangle(blurredSourceX, blurredSourceY, blurredSourceWidth, blurredSourceHeight),
+                    srcRect: new Rectangle(spaceFillingSourceX, spaceFillingSourceY, spaceFillingSourceWidth, spaceFillingSourceHeight),
                     GraphicsUnit.Pixel);
-
-                // If it is a wide image, don't blur the enlarged space-filling image;
-                // we'll take that one as-is, and ignore the scaled-to-fit image. Wide
-                // titlepic images tend to be designed to fit in 4:3.
-                bool isWide = scalingPercentW < scalingPercentH;
-                if (!isWide)
-                {
-                    bmPhoto = Blur(bmPhoto, new Rectangle(0, 0, width, height), 8);
-
-                    grPhoto = Graphics.FromImage(bmPhoto);
-
-                    // The real one
-                    grPhoto.DrawImage(imgPhoto,
-                        destRect: new Rectangle(destX, destY, destWidth, destHeight),
-                        srcRect: new Rectangle(sourceX, sourceY, sourceWidth, sourceHeight),
-                        GraphicsUnit.Pixel);
-                }
             }
 
             grPhoto.Dispose();
             return bmPhoto;
-        }
-
-        private static Bitmap Blur(Bitmap image, Rectangle rectangle, Int32 blurSize)
-        {
-            Bitmap blurred = new Bitmap(image.Width, image.Height);
-
-            // make an exact copy of the bitmap provided
-            using (Graphics graphics = Graphics.FromImage(blurred))
-                graphics.DrawImage(image, new Rectangle(0, 0, image.Width, image.Height),
-                    new Rectangle(0, 0, image.Width, image.Height), GraphicsUnit.Pixel);
-
-            // look at every pixel in the blur rectangle
-            for (int xx = rectangle.X; xx < rectangle.X + rectangle.Width; xx++)
-            {
-                for (int yy = rectangle.Y; yy < rectangle.Y + rectangle.Height; yy++)
-                {
-                    int avgR = 0, avgG = 0, avgB = 0;
-                    int blurPixelCount = 0;
-
-                    // average the color of the red, green and blue for each pixel in the
-                    // blur size while making sure you don't go outside the image bounds
-                    for (int x = xx; (x < xx + blurSize && x < image.Width); x++)
-                    {
-                        for (int y = yy; (y < yy + blurSize && y < image.Height); y++)
-                        {
-                            Color pixel = blurred.GetPixel(x, y);
-
-                            avgR += pixel.R;
-                            avgG += pixel.G;
-                            avgB += pixel.B;
-
-                            blurPixelCount++;
-                        }
-                    }
-
-                    avgR = avgR / blurPixelCount;
-                    avgG = avgG / blurPixelCount;
-                    avgB = avgB / blurPixelCount;
-
-                    // now that we know the average for the blur size, set each pixel to that color
-                    for (int x = xx; x < xx + blurSize && x < image.Width && x < rectangle.Width; x++)
-                        for (int y = yy; y < yy + blurSize && y < image.Height && y < rectangle.Height; y++)
-                            blurred.SetPixel(x, y, Color.FromArgb(avgR, avgG, avgB));
-                }
-            }
-
-            return blurred;
         }
     }
 }

--- a/DoomLauncher/Handlers/ImageExtensions.cs
+++ b/DoomLauncher/Handlers/ImageExtensions.cs
@@ -63,7 +63,7 @@ namespace DoomLauncher
                 nPercent = nPercentW;
                 destY = Convert.ToInt16((height - (sourceHeight * nPercent)) / 2);
                 blurredSourceWidth = Convert.ToInt16(sourceWidth * nPercent);
-                blurredSourceX = sourceWidth/ 2 - blurredSourceWidth / 2;
+                blurredSourceX = sourceWidth / 2 - blurredSourceWidth / 2;
 
             }
 
@@ -76,15 +76,6 @@ namespace DoomLauncher
             Graphics grPhoto = Graphics.FromImage(bmPhoto);
             grPhoto.Clear(backColor);
             grPhoto.InterpolationMode = InterpolationMode.HighQualityBicubic;
-
-            // The blurred one
-            grPhoto.DrawImage(imgPhoto,
-                destRect: new Rectangle(0, 0, width, height),
-                srcRect: new Rectangle(blurredSourceX, blurredSourceY, blurredSourceWidth, blurredSourceHeight),
-                GraphicsUnit.Pixel);
-
-            bmPhoto = Blur(bmPhoto, new Rectangle(0, 0, width, height), 8);
-            grPhoto = Graphics.FromImage(bmPhoto);
 
             // The real one
             grPhoto.DrawImage(imgPhoto,
@@ -185,53 +176,6 @@ namespace DoomLauncher
                 if (ymin > point.Y) ymin = point.Y;
                 if (ymax < point.Y) ymax = point.Y;
             }
-        }
-
-        private static Bitmap Blur(Bitmap image, Rectangle rectangle, Int32 blurSize)
-        {
-            Bitmap blurred = new Bitmap(image.Width, image.Height);
-
-            // make an exact copy of the bitmap provided
-            using (Graphics graphics = Graphics.FromImage(blurred))
-                graphics.DrawImage(image, new Rectangle(0, 0, image.Width, image.Height),
-                    new Rectangle(0, 0, image.Width, image.Height), GraphicsUnit.Pixel);
-
-            // look at every pixel in the blur rectangle
-            for (int xx = rectangle.X; xx < rectangle.X + rectangle.Width; xx++)
-            {
-                for (int yy = rectangle.Y; yy < rectangle.Y + rectangle.Height; yy++)
-                {
-                    int avgR = 0, avgG = 0, avgB = 0;
-                    int blurPixelCount = 0;
-
-                    // average the color of the red, green and blue for each pixel in the
-                    // blur size while making sure you don't go outside the image bounds
-                    for (int x = xx; (x < xx + blurSize && x < image.Width); x++)
-                    {
-                        for (int y = yy; (y < yy + blurSize && y < image.Height); y++)
-                        {
-                            Color pixel = blurred.GetPixel(x, y);
-
-                            avgR += pixel.R;
-                            avgG += pixel.G;
-                            avgB += pixel.B;
-
-                            blurPixelCount++;
-                        }
-                    }
-
-                    avgR = avgR / blurPixelCount;
-                    avgG = avgG / blurPixelCount;
-                    avgB = avgB / blurPixelCount;
-
-                    // now that we know the average for the blur size, set each pixel to that color
-                    for (int x = xx; x < xx + blurSize && x < image.Width && x < rectangle.Width; x++)
-                        for (int y = yy; y < yy + blurSize && y < image.Height && y < rectangle.Height; y++)
-                            blurred.SetPixel(x, y, Color.FromArgb(avgR, avgG, avgB));
-                }
-            }
-
-            return blurred;
         }
     }
 }

--- a/DoomLauncher/Handlers/ImageExtensions.cs
+++ b/DoomLauncher/Handlers/ImageExtensions.cs
@@ -42,6 +42,10 @@ namespace DoomLauncher
             int sourceY = 0;
             int destX = 0;
             int destY = 0;
+            int blurredSourceWidth = sourceWidth;
+            int blurredSourceHeight = sourceHeight;
+            int blurredSourceX = sourceX;
+            int blurredSourceY = sourceY;
 
             float nPercent;
             float nPercentW = width / (float)sourceWidth;
@@ -51,11 +55,16 @@ namespace DoomLauncher
             {
                 nPercent = nPercentH;
                 destX = Convert.ToInt16((width - (sourceWidth * nPercent)) / 2);
+                blurredSourceHeight = Convert.ToInt16(sourceHeight * nPercent);
+                blurredSourceY = sourceHeight / 2 - blurredSourceHeight / 2;
             }
             else
             {
                 nPercent = nPercentW;
                 destY = Convert.ToInt16((height - (sourceHeight * nPercent)) / 2);
+                blurredSourceWidth = Convert.ToInt16(sourceWidth * nPercent);
+                blurredSourceX = sourceWidth/ 2 - blurredSourceWidth / 2;
+
             }
 
             int destWidth = (int)(sourceWidth * nPercent);
@@ -68,9 +77,19 @@ namespace DoomLauncher
             grPhoto.Clear(backColor);
             grPhoto.InterpolationMode = InterpolationMode.HighQualityBicubic;
 
+            // The blurred one
             grPhoto.DrawImage(imgPhoto,
-                new Rectangle(destX, destY, destWidth, destHeight),
-                new Rectangle(sourceX, sourceY, sourceWidth, sourceHeight),
+                destRect: new Rectangle(0, 0, width, height),
+                srcRect: new Rectangle(blurredSourceX, blurredSourceY, blurredSourceWidth, blurredSourceHeight),
+                GraphicsUnit.Pixel);
+
+            bmPhoto = Blur(bmPhoto, new Rectangle(0, 0, width, height), 8);
+            grPhoto = Graphics.FromImage(bmPhoto);
+
+            // The real one
+            grPhoto.DrawImage(imgPhoto,
+                destRect: new Rectangle(destX, destY, destWidth, destHeight),
+                srcRect: new Rectangle(sourceX, sourceY, sourceWidth, sourceHeight),
                 GraphicsUnit.Pixel);
 
             grPhoto.Dispose();
@@ -166,6 +185,53 @@ namespace DoomLauncher
                 if (ymin > point.Y) ymin = point.Y;
                 if (ymax < point.Y) ymax = point.Y;
             }
+        }
+
+        private static Bitmap Blur(Bitmap image, Rectangle rectangle, Int32 blurSize)
+        {
+            Bitmap blurred = new Bitmap(image.Width, image.Height);
+
+            // make an exact copy of the bitmap provided
+            using (Graphics graphics = Graphics.FromImage(blurred))
+                graphics.DrawImage(image, new Rectangle(0, 0, image.Width, image.Height),
+                    new Rectangle(0, 0, image.Width, image.Height), GraphicsUnit.Pixel);
+
+            // look at every pixel in the blur rectangle
+            for (int xx = rectangle.X; xx < rectangle.X + rectangle.Width; xx++)
+            {
+                for (int yy = rectangle.Y; yy < rectangle.Y + rectangle.Height; yy++)
+                {
+                    int avgR = 0, avgG = 0, avgB = 0;
+                    int blurPixelCount = 0;
+
+                    // average the color of the red, green and blue for each pixel in the
+                    // blur size while making sure you don't go outside the image bounds
+                    for (int x = xx; (x < xx + blurSize && x < image.Width); x++)
+                    {
+                        for (int y = yy; (y < yy + blurSize && y < image.Height); y++)
+                        {
+                            Color pixel = blurred.GetPixel(x, y);
+
+                            avgR += pixel.R;
+                            avgG += pixel.G;
+                            avgB += pixel.B;
+
+                            blurPixelCount++;
+                        }
+                    }
+
+                    avgR = avgR / blurPixelCount;
+                    avgG = avgG / blurPixelCount;
+                    avgB = avgB / blurPixelCount;
+
+                    // now that we know the average for the blur size, set each pixel to that color
+                    for (int x = xx; x < xx + blurSize && x < image.Width && x < rectangle.Width; x++)
+                        for (int y = yy; y < yy + blurSize && y < image.Height && y < rectangle.Height; y++)
+                            blurred.SetPixel(x, y, Color.FromArgb(avgR, avgG, avgB));
+                }
+            }
+
+            return blurred;
         }
     }
 }

--- a/DoomLauncher/Handlers/Play/PlayHook.cs
+++ b/DoomLauncher/Handlers/Play/PlayHook.cs
@@ -1,0 +1,11 @@
+﻿
+using DoomLauncher.Interfaces;
+
+namespace DoomLauncher.Handlers.Play
+{
+    public interface PlayHook
+    {
+        void BeforePlay(IGameFile gamefile, ISourcePortData sourcePort);
+        void AfterPlay(IGameFile gamefile, ISourcePortData sourcePort);
+    }
+}

--- a/DoomLauncher/Handlers/Play/SaveGamesPlayHook.cs
+++ b/DoomLauncher/Handlers/Play/SaveGamesPlayHook.cs
@@ -1,0 +1,97 @@
+﻿
+using DoomLauncher.Config;
+using DoomLauncher.DataSources;
+using DoomLauncher.Interfaces;
+using DoomLauncher.SourcePort;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace DoomLauncher.Handlers.Play
+{
+    public class SaveGamesPlayHook : PlayHook
+    {
+        private List<IFileData> m_saveGames;
+        private readonly SaveGameHandler m_saveGameHandler;
+        private readonly IDirectoriesConfiguration m_config;
+        private readonly List<INewFileDetector> m_saveFileDetectors;
+
+
+        public SaveGamesPlayHook(SaveGameHandler saveGameHandler)
+        {
+            m_saveGameHandler = saveGameHandler;
+        }
+
+        public void BeforePlay(IGameFile gameFile, ISourcePortData sourcePort)
+        {
+            var fileHandler = new FileHandler(m_database, m_config);
+            m_saveGames = fileHandler.GetFiles(gameFile, FileType.SaveGame).Where(x => x.SourcePortID == sourcePort.SourcePortID).ToArray();
+
+            m_saveGames.ToList().ForEach(file => m_saveGameHandler.CopySaveGameToSourcePort(sourcePort, file));
+        }
+
+        public void AfterPlay(IGameFile gameFile, ISourcePortData sourcePort)
+        {
+
+            var newSaveGames = GetNewSaveGames(m_saveFileDetectors, m_saveGames).ToList();
+            newSaveGames.ForEach(file => m_saveGameHandler.InsertSaveGame(sourcePort, gameFile, file));
+
+            var updatedSaveGames = m_saveGames.ToList();
+            updatedSaveGames.ForEach(file => m_saveGameHandler.UpdateSaveGameFromSourcePort(sourcePort, file));
+
+            var deletedSaveGames = GetDeletedSaveGames(m_saveFileDetectors).ToList();
+            deletedSaveGames.ForEach(file => m_saveGameHandler.DeleteSaveGame(file, m_saveGames));
+        }
+        private static string[] GetNewSaveGames(List<INewFileDetector> saveFileDetectors, List<IFileData> existingSaves)
+        {
+            IEnumerable<string> newFiles = new string[] { };
+            saveFileDetectors.ForEach(x => newFiles = newFiles.Union(x.GetNewFiles()));
+
+            IEnumerable<string> modifiedFiles = new string[] { };
+            saveFileDetectors.ForEach(x => modifiedFiles = modifiedFiles.Union(x.GetModifiedFiles()));
+
+            //modified files uses full path, m_saveGames does not. This section checks for modified files that were not part of the gamefile's save games
+            //e.g save0.zds was a save game for this gamefile. User overwrites save1.zds for this gamefile. We now need to keep track of save1.zds as well.
+            IEnumerable<string> saveFiles = existingSaves.Select(x => x.OriginalFileName);
+            List<string> ret = newFiles.ToList();
+            foreach (string modifiedFile in modifiedFiles)
+            {
+                FileInfo fi = new FileInfo(modifiedFile);
+                if (!saveFiles.Contains(fi.Name) && !ret.Contains(fi.Name))
+                    ret.Add(modifiedFile);
+            }
+
+            return ret.ToArray();
+        }
+
+        private static string[] GetDeletedSaveGames(List<INewFileDetector> saveFileDetectors)
+        {
+            IEnumerable<string> deletedFiles = new string[] { };
+            saveFileDetectors.ForEach(x => deletedFiles = deletedFiles.Union(x.GetDeletedFiles()));
+            return deletedFiles.ToArray();
+        }
+
+        private void CreateFileDetectors(ISourcePortData sourcePortData)
+        {
+            ISourcePortFlavor sourcePortFlavor = sourcePortData.GetFlavor();
+            //CreateScreenshotDetectors(sourcePortData, sourcePortFlavor);
+            CreateSaveGameDetectors(sourcePortData, sourcePortFlavor);
+        }
+
+        private void CreateSaveGameDetectors(ISourcePortData sourcePortData, ISourcePortFlavor sourcePort)
+        {
+            m_saveFileDetectors = CreateDefaultSaveGameDetectors();
+            m_saveFileDetectors.Add(CreateSaveGameDetector(sourcePortData.GetReadSavePath().GetFullPath()));
+
+            foreach (var saveDir in sourcePort.GetSaveGameDirectories())
+            {
+                if (!string.IsNullOrEmpty(saveDir) && Directory.Exists(saveDir))
+                    m_saveFileDetectors.Add(CreateSaveGameDetector(saveDir));
+            }
+
+            Array.ForEach(m_saveFileDetectors.ToArray(), x => x.StartDetection());
+        }
+
+    }
+}


### PR DESCRIPTION
Introduces 4:3 thumbnail images. You can resync individual images to see the new version, or do `update GameFiles set IsSyncRequired = 1` in Sqlite to force everything to update as they are displayed. IsSyncRequired will be set to 1 for every game file in the next version, so users don't need to do anything for all the images to get fixed. (This is very slow and bad UX, but I will look at a fix for this in the next PR)

- Overwhelming majority of images naturally fill the available space
- Images with the wrong aspect ratio scale up to fill the space, truncating the sides, which looks fine for all the official games - Doom, Doom II, Plutonia, Sigil, etc, and seems to pan out fine for others like Pirate Doom 2, Eviternity 2 etc. Seems to look good for screenshot thumbnails too, which could be any aspect ratio

Addresses https://github.com/nstlaurent/DoomLauncher/issues/321 and https://github.com/nstlaurent/DoomLauncher/issues/176