### PR TITLE
Update map regex to not parse the first property of defaultmap as a map

### DIFF
--- a/DoomLauncher/Handlers/Sync/MapStringSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/MapStringSyncAction.cs
@@ -13,7 +13,7 @@ namespace DoomLauncher.Handlers.Sync
     public class MapStringSyncAction : ISyncAction
     {
         private readonly LauncherPath m_tempDirectory;
-        private static readonly Regex MapRegex = new Regex(@"\s*map\s+\w+", RegexOptions.IgnoreCase);
+        private static readonly Regex MapRegex = new Regex(@"(?<!\S)map\s+\w+", RegexOptions.IgnoreCase);
         private static readonly Regex IncludeRegex = new Regex(@"\s*include\s+(\S+)", RegexOptions.IgnoreCase);
 
         public MapStringSyncAction(LauncherPath tempDirectory)

--- a/UnitTest/Tests/TestMapStringSyncAction.cs
+++ b/UnitTest/Tests/TestMapStringSyncAction.cs
@@ -10,9 +10,13 @@ namespace UnitTest.Tests
     public class TestMapStringSyncAction
     {
         [TestMethod]
-        public void MapString()
+        public void MapStringWithBraces()
         {
             var mapInfo = @"
+                defaultmap {
+                    sky1 = ""testTexture""
+                }
+
                 map map01 {
                     music = ""test1""
                 }
@@ -20,6 +24,28 @@ namespace UnitTest.Tests
                 MAP MAP02 {
                     music = ""test2""
                 }
+            ";
+
+            var frag = new MapStringSyncAction(new LauncherPath(Directory.GetCurrentDirectory()));
+            var gameFile = new GameFile();
+            frag.ApplyToGameFile(gameFile, null, new string[] { mapInfo });
+
+            Assert.AreEqual("map01, MAP02", gameFile.Map);
+            Assert.AreEqual(2, gameFile.MapCount);
+        }
+
+        [TestMethod]
+        public void MapStringWithoutBraces()
+        {
+            var mapInfo = @"
+                defaultmap
+                    sky1 = ""testTexture""
+
+                map map01
+                    music = ""test1""
+
+                MAP MAP02
+                    music = ""test2""
             ";
 
             var frag = new MapStringSyncAction(new LauncherPath(Directory.GetCurrentDirectory()));


### PR DESCRIPTION
This only occurred if the MAPINFO didn't use curly braces.

The old regex allowed non-whitespace characters before 'map', the new regex disallows this.

Fixes #377.