### PR TITLE
Force picturebox paint to fire after image drawing

### DIFF
--- a/DoomLauncher/Controls/CPictureBox.cs
+++ b/DoomLauncher/Controls/CPictureBox.cs
@@ -32,6 +32,7 @@ namespace DoomLauncher.Controls
 
     public class CPictureBox : Control
     {
+        public new event EventHandler<PaintEventArgs> Paint;
         public event EventHandler LoadCompleted;
         public string FileLocation = "";
 
@@ -105,6 +106,12 @@ namespace DoomLauncher.Controls
         {
             base.OnPaint(e);
 
+            DrawImage(e);
+            Paint?.Invoke(this, new PaintEventArgs(e.Graphics, e.ClipRectangle));
+        }
+
+        private void DrawImage(PaintEventArgs e)
+        {
             if (m_image == null)
                 return;
 


### PR DESCRIPTION
Force paint even to fire after image drawing to match original .NET picturebox behavior.

Doom Launcher was using the event to draw things on top but default control behavior is apparently firing the event before. This caused the image to draw over the things Doom Launcher wanted to draw on top.