### PR TITLE
Users can override a titlepic with a screenshot as the main image

### DIFF
--- a/DoomLauncher/Adapters/DbDataSourceAdapter.cs
+++ b/DoomLauncher/Adapters/DbDataSourceAdapter.cs
@@ -521,7 +521,7 @@ namespace DoomLauncher
         {
             string query = @"update Files set 
             SourcePortID = @SourcePortID, Description = @Description, FileOrder = @FileOrder, DateCreated = @DateCreated,
-            UserTitle = @UserTitle, UserDescription = @UserDescription, Map = @Map
+            UserTitle = @UserTitle, UserDescription = @UserDescription, Map = @Map, IsMain = @IsMain
             where FileID = @FileID";
 
             List<DbParameter> parameters = new List<DbParameter>
@@ -534,6 +534,7 @@ namespace DoomLauncher
                 DataAccess.DbAdapter.CreateParameter("UserTitle", file.UserTitle),
                 DataAccess.DbAdapter.CreateParameter("Map", file.Map),
                 DataAccess.DbAdapter.CreateParameter("UserDescription", file.UserDescription),
+                DataAccess.DbAdapter.CreateParameter("IsMain", file.IsMain)
             };
 
             DataAccess.ExecuteNonQuery(query, parameters);

--- a/DoomLauncher/Config/AppVersion.cs
+++ b/DoomLauncher/Config/AppVersion.cs
@@ -44,5 +44,6 @@
         Version_3_7_8,
         Version_3_7_9,
         Version_3_7_9_Update1,
+        Version_3_7_9_Update2,
     }
 }

--- a/DoomLauncher/Controls/GameFileAssociationView.cs
+++ b/DoomLauncher/Controls/GameFileAssociationView.cs
@@ -8,6 +8,11 @@ namespace DoomLauncher
 {
     public partial class GameFileAssociationView : UserControl
     {
+        // For some reason the Names of the toolstrip items (eg "btnSetFirst") 
+        // are disappearing at runtime, so the best we can do right now is use Text
+        // like a crap identifier.
+        public static readonly string SetFirstButtonText = "Set First";
+
         public event EventHandler FileAdded;
         public event EventHandler FileDeleted;
         public event EventHandler FileOrderChanged;

--- a/DoomLauncher/Controls/ScreenshotView.cs
+++ b/DoomLauncher/Controls/ScreenshotView.cs
@@ -1,5 +1,4 @@
-﻿using DoomLauncher.DataSources;
-using DoomLauncher.Forms;
+﻿using DoomLauncher.Forms;
 using DoomLauncher.Handlers;
 using DoomLauncher.Interfaces;
 using System;
@@ -33,6 +32,11 @@ namespace DoomLauncher
 
     public partial class ScreenshotView : BasicFileView
     {
+        // For some reason, Names of ToolStripItems are disappearing at runtime, 
+        // so we need to use Text as the identifier.
+        private static readonly string SetAsMainImageButtonText = "Set as main image";
+        private static readonly string RemoveAsMainImageButtonText = "Remove as main image";
+
         private const double AspectWidth = 16;
         private const double AspectHeight = 9;
         private readonly Dictionary<PictureBox, IFileData> m_lookup = new Dictionary<PictureBox, IFileData>();
@@ -174,12 +178,25 @@ namespace DoomLauncher
 
         public override bool SetFileOrderFirst()
         {
-            if (base.SetFileOrderFirst())
+            IFileData selectedFile = GetSelectedFiles().FirstOrDefault();
+
+            if (selectedFile != null)
             {
+                selectedFile.IsMain = !selectedFile.IsMain;
+                DataSourceAdapter.UpdateFile(selectedFile);
+
+                foreach (var file in Files)
+                {
+                    if (file.FileID != selectedFile.FileID)
+                    {
+                        file.IsMain = false;
+                        DataSourceAdapter.UpdateFile(file);
+                    }
+                }
+
                 m_gameFileImageHandler.UpdateImages(GameFile);
                 return true;
             }
-
             return false;
         }
 
@@ -329,6 +346,7 @@ namespace DoomLauncher
             pbScreen.Margin = new Padding(7);
             pbScreen.MouseDown += pbScreen_MouseDown;
             pbScreen.DoubleClick += PbScreen_DoubleClick;
+
             pbScreen.Paint += PbScreen_Paint;
             return pbScreen;
         }
@@ -340,10 +358,15 @@ namespace DoomLauncher
                 return;
 
             string title = fileData.Title;
-            if (string.IsNullOrEmpty(title))
-                return;
+            if (!string.IsNullOrEmpty(title))
+            {
+                Util.DrawImageTitleBar(title, pb.ClientRectangle, e, Brushes.White, Font);
+            }
 
-            Util.DrawImageTitleBar(title, pb.ClientRectangle, e, Brushes.White, Font);
+            if (fileData.IsMain)
+            {
+                Util.DrawImageTitleBar("Main image", pb.ClientRectangle, e, Brushes.LightGray, Font, top: true);
+            }
         }
 
         private void PbScreen_DoubleClick(object sender, EventArgs e)
@@ -411,7 +434,26 @@ namespace DoomLauncher
             }
 
             if (e != null && e.Button == MouseButtons.Right)
+            {
+                ToolStripItem setAsMainItem = GetSetAsMainToolStripItem();
+
+                if (setAsMainItem != null)
+                {
+                    bool isMain = SelectedFile != null && SelectedFile.IsMain;
+                    setAsMainItem.Text = isMain ? RemoveAsMainImageButtonText : SetAsMainImageButtonText;
+                }
+
                 m_menu.Show(pb.PointToScreen(e.Location));
+            }
+        }
+
+        private ToolStripItem GetSetAsMainToolStripItem()
+        {
+            List<ToolStripItem> toolStripItems = m_menu.Items.Cast<ToolStripItem>().ToList();
+            return toolStripItems.FirstOrDefault(
+                item => item.Text == GameFileAssociationView.SetFirstButtonText
+                     || item.Text == SetAsMainImageButtonText
+                     || item.Text == RemoveAsMainImageButtonText);
         }
 
         private void SetSelectedStyle(PictureBox pb, bool selected)

--- a/DoomLauncher/DataSources/FileData.cs
+++ b/DoomLauncher/DataSources/FileData.cs
@@ -24,6 +24,7 @@ namespace DoomLauncher
         public string UserDescription { get; set; }
         public string Map { get; set; }
         public int FileOrder { get; set; }
+        public bool IsMain { get; set; }
         public FileType DerivedFileType { get; set; }
 
         public virtual bool IsUrl { get { return false; } }

--- a/DoomLauncher/Handlers/Files/GameFileImageHandler.cs
+++ b/DoomLauncher/Handlers/Files/GameFileImageHandler.cs
@@ -38,7 +38,7 @@ namespace DoomLauncher.Handlers
         {
             if (gameFile.GameFileID.HasValue)
             {
-                IFileData bestImage = m_fileHandler.GetFiles(gameFile, FileType.TitlePic, FileType.Screenshot).FirstOrDefault();
+                IFileData bestImage = GetBestMainImage(gameFile);
                 return bestImage ?? CreateTileImage(gameFile);
             }
             else
@@ -135,13 +135,30 @@ namespace DoomLauncher.Handlers
 
         public void UpdateImages(IGameFile gameFile)
         {
-            var mainImage = m_fileHandler.GetFiles(gameFile, FileType.TitlePic, FileType.Screenshot).FirstOrDefault();
+            var mainImage = GetBestMainImage(gameFile);
             if (mainImage != null)
             {
                 m_fileHandler.DeleteFiles(gameFile, FileType.TileImage);
                 m_fileHandler.DeleteFiles(gameFile, FileType.Thumbnail);
                 CreateAndInsertThumbnail(gameFile, mainImage);
             }
+        }
+
+        private IFileData GetBestMainImage(IGameFile gameFile)
+        {
+            var candidateImages = m_fileHandler.GetFiles(gameFile, FileType.TitlePic, FileType.Screenshot);
+            IFileData bestImage = candidateImages.FirstOrDefault();
+
+            // Override the title pic with a screenshot if one is marked as "IsMain"
+            foreach (var image in candidateImages)
+            {
+                if (image.FileTypeID == FileType.Screenshot && image.IsMain)
+                {
+                    bestImage = image;
+                    break;
+                }
+            }
+            return bestImage;
         }
 
         private IFileData CreateAndInsertThumbnail(IGameFile gameFile, IFileData parent)

--- a/DoomLauncher/Handlers/Util.cs
+++ b/DoomLauncher/Handlers/Util.cs
@@ -547,7 +547,7 @@ namespace DoomLauncher
 
         private static readonly SolidBrush RectangleBrush = new SolidBrush(Color.FromArgb(128, Color.Black));
 
-        public static void DrawImageTitleBar(string title, Rectangle paintRect, PaintEventArgs e, Brush textBrush, Font font)
+        public static void DrawImageTitleBar(string title, Rectangle paintRect, PaintEventArgs e, Brush textBrush, Font font, bool top = false)
         {
             if (string.IsNullOrEmpty(title))
                 return;
@@ -558,10 +558,12 @@ namespace DoomLauncher
             title = GetClippedEllipsesText(e.Graphics, font, title, new SizeF(paintRect.Width, font.Height));
 
             SizeF size = e.Graphics.MeasureString(title, font);
-            RectangleF rect = new RectangleF(0, paintRect.Height - size.Height - padY,
-                e.ClipRectangle.Width, size.Height + padY);
+            var rectY = top ? 0 : paintRect.Height - size.Height - padY;
+            var textY = top ? padY : paintRect.Height - size.Height - padY;
+
+            RectangleF rect = new RectangleF(0, rectY, e.ClipRectangle.Width, size.Height + padY);
             e.Graphics.FillRectangle(RectangleBrush, rect);
-            e.Graphics.DrawString(title, font, textBrush, new PointF(padX, paintRect.Height - size.Height - padY));
+            e.Graphics.DrawString(title, font, textBrush, new PointF(padX, textY));
         }
     }
 }

--- a/DoomLauncher/Handlers/VersionHandler.cs
+++ b/DoomLauncher/Handlers/VersionHandler.cs
@@ -99,6 +99,7 @@ namespace DoomLauncher
                 ExecuteUpdate(Pre_Version_3_7_8, AppVersion.Version_3_7_8);
                 ExecuteUpdate(Pre_Version_3_7_9, AppVersion.Version_3_7_9);
                 ExecuteUpdate(Pre_Version_3_7_9_Update1, AppVersion.Version_3_7_9_Update1);
+                ExecuteUpdate(Pre_Version_3_7_9_Update2, AppVersion.Version_3_7_9_Update2);
             }
 
             return new VersionUpdateResults(m_restartRequired);
@@ -981,6 +982,15 @@ namespace DoomLauncher
                 UserCanModify = true,
                 AvailableValues = "16:9;0;4:3;1"
             });
+        }
+
+        private void Pre_Version_3_7_9_Update2()
+        {
+            var dt = DataAccess.ExecuteSelect("pragma table_info(Files);").Tables[0];
+            if (!dt.Select("name = 'IsMain'").Any())
+            {
+                DataAccess.ExecuteNonQuery("alter table Files add column 'IsMain' INTEGER NOT NULL DEFAULT 0;");
+            }
         }
 
         private void UpdateSourcePortsTable()

--- a/DoomLauncher/Interfaces/IFileData.cs
+++ b/DoomLauncher/Interfaces/IFileData.cs
@@ -18,7 +18,7 @@ namespace DoomLauncher.Interfaces
         string Map { get; set; }
         int FileOrder { get; set; }
         bool IsUrl { get; }
-
+        bool IsMain { get; set; }
         int? DerivedFromFileID { get; set; }
         string Title { get; }
         FileType DerivedFileType { get; set; }

--- a/UnitTest/Tests/TestFile.cs
+++ b/UnitTest/Tests/TestFile.cs
@@ -31,8 +31,8 @@ namespace UnitTest.Tests
 
             var gameFileId = 37;
 
-            var file1 = 
-                new FileData 
+            var file1 =
+                new FileData
                 {
                     FileName = "Rabbits.txt",
                     FileTypeID = FileType.SaveGame,
@@ -44,7 +44,8 @@ namespace UnitTest.Tests
                     OriginalFileName = "Bunnies.txt",
                     UserTitle = "All about rabbits",
                     UserDescription = "I didn't understand it",
-                    Map = "zzz"
+                    Map = "zzz",
+                    IsMain = true
                 };
 
             var file2 =
@@ -114,7 +115,8 @@ namespace UnitTest.Tests
                     OriginalFileName = "hongse.txt",
                     UserTitle = "It's another color",
                     UserDescription = "Primary color, a bit angry",
-                    Map = "yyy"
+                    Map = "yyy",
+                    IsMain = false
                 };
 
             var wrongGameIdFile =
@@ -176,7 +178,8 @@ namespace UnitTest.Tests
                     OriginalFileName = "hippopotamus.txt",
                     UserTitle = "I like hippos",
                     UserDescription = "They are very hungry",
-                    Map = "hjkl"
+                    Map = "hjkl",
+                    IsMain = true
                 };
 
             var file2 =
@@ -192,7 +195,8 @@ namespace UnitTest.Tests
                     OriginalFileName = "giraffe_pattern.txt",
                     UserTitle = "Long neck giraffe",
                     UserDescription = "Why are their necks so long",
-                    Map = "aaa"
+                    Map = "aaa",
+                    IsMain = false
                 };
 
             database.InsertFile(file1);
@@ -281,7 +285,8 @@ namespace UnitTest.Tests
                     OriginalFileName = "caco.txt",
                     UserTitle = "The fanciest demon",
                     UserDescription = "Three double shotty hits on a good day",
-                    Map = "yyy"
+                    Map = "yyy",
+                    IsMain = true
                 };
 
             var file2 =
@@ -297,7 +302,8 @@ namespace UnitTest.Tests
                     OriginalFileName = "impy.txt",
                     UserTitle = "One shotty blast",
                     UserDescription = "Two if you miss",
-                    Map = "yyy"
+                    Map = "yyy",
+                    IsMain = false
                 };
 
             var wrongFile =
@@ -347,7 +353,8 @@ namespace UnitTest.Tests
                     OriginalFileName = "paine.txt",
                     UserTitle = "What if a demon shot more demons out of its mouth",
                     UserDescription = "What if a pain elemental shot more pain elementals out of its mouth",
-                    Map = "s34"
+                    Map = "s34",
+                    IsMain = false
                 };
 
             var wrongFile =
@@ -381,6 +388,7 @@ namespace UnitTest.Tests
             savedFile1.UserTitle = "New UserTitle";
             savedFile1.UserDescription = "New UserDescription";
             savedFile1.Map = "New map";
+            savedFile1.IsMain = true;
             database.UpdateFile(savedFile1);
 
             var updatedFiles = database.GetFiles(new GameFile { GameFileID = 222 });
@@ -395,6 +403,7 @@ namespace UnitTest.Tests
             Assert.AreEqual("New UserTitle", retrieved1.UserTitle);
             Assert.AreEqual("New UserDescription", retrieved1.UserDescription);
             Assert.AreEqual("New map", retrieved1.Map);
+            Assert.IsTrue(retrieved1.IsMain);
 
             // The other record was unaffected
             var retrieved2 = updatedFiles.Where(x => x.FileName.Equals(wrongFile.FileName)).First();


### PR DESCRIPTION
Addresses #387, which reinstates the ability to override a titlepic with a screenshot as the main image.

## Solution
- This is implemented with an `IsMain` boolean column added to the Files database table. This is only used by screenshots, but could conceivably have some other meaning for the other FileTypes in the future.
- When right-clicking on a screenshot in the ScreenshotView, the "Set First" toolstrip item is replaced with "Set as main image". This is based on the assumption that "Set First" only really exists to make a screenshot the main image anyway. 
- When the screenshot is already set as the main image, the toolstrip item will be called "Remove as main image" and will toggle the setting. 
- When set as main image, a "Main image" banner will be displayed at the top of the screenshot's tile. This can exist at the same time as the user-configured "Title", which is still displayed as a banner at the bottom of the tile.

## Implementation notes
- I haven't added any new tests; the logic is largely UI-bound. While not impossible, I don't wish to refactor GameAssociationFileView & friends at this time, that will be a bit of work. I have, however, added `IsMain` to the fields tested in the existing TestFile suite.
- Somehow `Name` is disappearing from ToolStripItems at runtime, so I couldn't refer to the crucial item as `btnSetFirst`, and had to implement a hack based on the `Text` label. This hack doesn't leave a big footprint on the code fortunately, but it is regrettable.
- Where a titlepic is not present, the existing logic of selecting the first screenshot still applies. Setting another screenshot as "main image" will override it in the same way.
- I originally tried encoding `FileOrder = -1` as a special kind of first, and using the `<` and `>` buttons to elevate a 0 to a -1, and using a red border instead of blue to differentiate it. This was irritating and unintuitive to use; the `IsMain` toggle is a much better experience.