### PR TITLE
Doom64 playform fix

### DIFF
--- a/DoomLauncher/Forms/PlayForm.cs
+++ b/DoomLauncher/Forms/PlayForm.cs
@@ -198,11 +198,7 @@ namespace DoomLauncher
                 if (gameProfile.SourcePortID.HasValue)
                     SelectedSourcePort = m_adapter.GetSourcePort(gameProfile.SourcePortID.Value);
 
-                var isDoom64 = GameFile.IsDoom64;
-                isDoom64 = false;
-
-                
-                if (isDoom64)
+                if (GameFile.IsDoom64)
                 {
                     SelectedSourcePort = m_adapter.GetDoom64().FirstOrDefault();
                     cmbSourcePorts.Enabled = false;

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,3 +8,4 @@
 
 ## Bug Fixes:
 - Upgraded SharpCompress utility to eliminate moderate vulnerability
+- PlayForm functions correctly for Doom64 maps


### PR DESCRIPTION
Addresses #404.

Removes a line in the PlayForm that was preventing the form from setting itself up for Doom64.