### PR TITLE
Ignore file in use exceptions for 

### DIFF
--- a/DoomLauncher/Adapters/Launch/GameFilesLaunchFeature.cs
+++ b/DoomLauncher/Adapters/Launch/GameFilesLaunchFeature.cs
@@ -99,7 +99,7 @@ namespace DoomLauncher.Adapters.Launch
                         {
                             string extractFile = Path.Combine(directories.TempDirectory.GetFullPath(), entry.Name);
                             if (m_extractFiles)
-                                entry.ExtractToFileForceOverwrite(extractFile);
+                                entry.ExtractToFileForceOverwrite(extractFile, throwIfInUse: false);
                             launchFiles.Add(extractFile);
                         }
                         else

--- a/DoomLauncher/Adapters/Launch/IWadLaunchFeature.cs
+++ b/DoomLauncher/Adapters/Launch/IWadLaunchFeature.cs
@@ -68,7 +68,7 @@ namespace DoomLauncher.Adapters.Launch
                     { 
                         string extractFile = Path.Combine(directories.TempDirectory.GetFullPath(), firstMatchingEntry.Name);
                         if (_extractFiles)
-                            firstMatchingEntry.ExtractToFileForceOverwrite(extractFile);
+                            firstMatchingEntry.ExtractToFileForceOverwrite(extractFile, throwIfInUse: false);
                         return extractFile;
                     }
                     else

--- a/DoomLauncher/Archive/IArchiveEntry.cs
+++ b/DoomLauncher/Archive/IArchiveEntry.cs
@@ -1,4 +1,5 @@
-﻿using SharpCompress.Common;
+﻿using DoomLauncher.Handlers;
+using SharpCompress.Common;
 using System;
 using System.IO;
 
@@ -12,7 +13,7 @@ namespace DoomLauncher
         string FullName { get; }
         void ExtractToFile(string file, bool overwrite = false);
 
-        void ExtractToFileForceOverwrite(string file);
+        void ExtractToFileForceOverwrite(string file, bool throwIfInUse = true);
 
         bool ExtractRequired { get; }
         bool IsDirectory { get; }
@@ -29,7 +30,7 @@ namespace DoomLauncher
 
         public abstract void ExtractToFile(string file, bool overwrite = false);
 
-        public void ExtractToFileForceOverwrite(string file)
+        public void ExtractToFileForceOverwrite(string file, bool throwIfInUse = true)
         {
             try
             {
@@ -37,6 +38,12 @@ namespace DoomLauncher
             }
             catch (Exception ex)
             {
+                if (ex is IOException io)
+                {
+                    if (!throwIfInUse && io.IsInUse())
+                        return;
+                }
+
                 try
                 {
                     if (File.Exists(file))

--- a/DoomLauncher/DoomLauncher.csproj
+++ b/DoomLauncher/DoomLauncher.csproj
@@ -285,6 +285,7 @@
     <Compile Include="GameStores\Steam\SteamFileUtils.cs" />
     <Compile Include="GameStores\Steam\SteamLoader.cs" />
     <Compile Include="Handlers\AutoCompleteCombo.cs" />
+    <Compile Include="Handlers\ExceptionExtensions.cs" />
     <Compile Include="Handlers\Files\FileHandler.cs" />
     <Compile Include="Handlers\Files\GameFileImageHandler.cs" />
     <Compile Include="Handlers\Files\IFileHandler.cs" />

--- a/DoomLauncher/Handlers/ExceptionExtensions.cs
+++ b/DoomLauncher/Handlers/ExceptionExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.IO;
+
+namespace DoomLauncher.Handlers
+{
+    public static class ExceptionExtensions
+    {
+        const int ERROR_SHARING_VIOLATION = 0x20;
+        const int ERROR_LOCK_VIOLATION = 0x21;
+
+        public static bool IsInUse(this IOException ex)
+        {
+            var result = ex.HResult & 0xFFFF;
+            return result == ERROR_SHARING_VIOLATION || result == ERROR_LOCK_VIOLATION;
+        }
+    }
+}


### PR DESCRIPTION
Don't throw exception if the file is in use. This allows for the utility option to be used while playing with a source port. This also fixes the otherwise broken allow multiple play sessions option since the file will be locked by the first source port that launches.

fixes #399 