### PR TITLE
Fixes Hexen title image problems

### DIFF
--- a/DoomLauncher/GameStores/StoreGame.cs
+++ b/DoomLauncher/GameStores/StoreGame.cs
@@ -12,8 +12,8 @@ namespace DoomLauncher.GameStores
             null);
 
         public readonly static StoreGame HERETIC_PLUS_HEXEN = new StoreGame(3286930, 1572667751, "Heretic + Hexen",
-            new List<string> { @"base\heretic\heretic.wad", @"base\hexen\hexen.wad" },
-            new List<string> { @"base\hexendk\hexdd.wad" }, 
+            new List<string> { @"heretic.wad", @"hexen.wad" },
+            new List<string> { @"hexdd.wad" }, 
             null);
 
         public readonly static StoreGame DOOM2 = new StoreGame(2300, null, "DOOM II", 

--- a/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/TitlePicSyncAction.cs
@@ -39,7 +39,9 @@ namespace DoomLauncher.Handlers.Sync
             {
                 if (TitlePicUtil.GetEntry(reader, HereticHexenTitlepicName, out entry))
                 {
-                    if (IWadInfo.Hexen.Equals(file.IntendedGame) || "hexen".Equals(GetIWadFileNameBase(file.IWadID), StringComparison.OrdinalIgnoreCase))
+                    if (IWadInfo.Hexen.Equals(file.IntendedGame) 
+                        || "hexen".Equals(file.FileNameBase, StringComparison.OrdinalIgnoreCase) 
+                        || "hexen".Equals(GetIWadFileNameBase(file.IWadID), StringComparison.OrdinalIgnoreCase))
                         palette = m_hexenPalette;
                     else
                         palette = m_hereticPalette;

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -5,7 +5,10 @@
 - Aspect ratio config setting to choose between 16:9 and 4:3
 - "Resync recommended" button so that users can benefit from significant syncing improvements
 - TitlePics are no longer considered screenshots; right click on a screenshot to set as main image
+- Support for wide image title pic in Heretic + Hexen
 
 ## Bug Fixes:
 - Upgraded SharpCompress utility to eliminate moderate vulnerability
 - PlayForm functions correctly for Doom64 maps
+- Auto load from Steam/Gog corrrectly finds Heretic + Hexen wads
+- Hexen IWAD will use the correct palette for the title pic

--- a/UnitTest/Resources/TestSteamLibrary1/steamapps/appmanifest_2360.acf
+++ b/UnitTest/Resources/TestSteamLibrary1/steamapps/appmanifest_2360.acf
@@ -1,0 +1,8 @@
+"AppState"
+{
+	"bogus"		"agnhehj"
+	"appid"		"2360"
+	"name"		"Hexen"
+	"installdir"		"TestHexen"
+	"nonsense"		"3g5%%$#"
+}

--- a/UnitTest/Resources/TestSteamLibrary1/steamapps/appmanifest_3286930.acf
+++ b/UnitTest/Resources/TestSteamLibrary1/steamapps/appmanifest_3286930.acf
@@ -1,0 +1,8 @@
+"AppState"
+{
+	"blahblah"		"yyy"
+	"appid"		"3286930"
+	"name"		"Heretic + Hexen"
+	"installdir"		"TestHereticHexen"
+	"nonsense"		"123123"
+}

--- a/UnitTest/Resources/TestSteamLibrary1/steamapps/common/TestHereticHexen/hexen.wad
+++ b/UnitTest/Resources/TestSteamLibrary1/steamapps/common/TestHereticHexen/hexen.wad
@@ -1,0 +1,1 @@
+heretic + hexen.wad

--- a/UnitTest/Resources/TestSteamLibrary1/steamapps/common/TestHexen/base/hexen.wad
+++ b/UnitTest/Resources/TestSteamLibrary1/steamapps/common/TestHexen/base/hexen.wad
@@ -1,0 +1,1 @@
+hexen.wad

--- a/UnitTest/Tests/TestSteamFileUtils.cs
+++ b/UnitTest/Tests/TestSteamFileUtils.cs
@@ -20,7 +20,7 @@ namespace UnitTest.Tests
         [TestMethod]
         public void TryGetInstallDir_ReturnsFalseAndNullWhenAcfDoesNotExist()
         {
-            var path = Path.GetFullPath(@"Resources\TestSteamLibrary1\steamapps\appmanifest_2360.acf");
+            var path = Path.GetFullPath(@"Resources\TestSteamLibrary1\steamapps\appmanifest_317040.acf");
             var success = SteamFileUtils.TryGetInstallDir(path, out var installDir);
 
             Assert.IsFalse(success);

--- a/UnitTest/Tests/TestStoreGameLoader.cs
+++ b/UnitTest/Tests/TestStoreGameLoader.cs
@@ -18,9 +18,6 @@ namespace UnitTest.Tests
             // SteamGame.ULTIMATE_DOOM:
             // TestSteamLibrary1 / steamapps / common / TestDoom
 
-
-            GameFinder finder = _ => @"Resources\TestSteamLibrary1\steamapps\common\TestDoom";
-
             var gameStoreFiles = StoreGameLoader.LoadStoreGame(StoreGame.ULTIMATE_DOOM, @"Resources\TestSteamLibrary1\steamapps\common\TestDoom");
 
             var iwads = gameStoreFiles.InstalledIWads;
@@ -39,10 +36,40 @@ namespace UnitTest.Tests
         }
 
         [TestMethod]
+        public void LoadAllStoreGames_FindsWadsInExpectedPriorityOrder()
+        {
+            // Assuming fixtures:
+
+            // SteamGame.HERETIC_PLUS_HEXEN:
+            // TestSteamLibrary1 / steamapps / common / TestHereticHexen
+
+            // SteamGame.HEXEN:
+            // TestSteamLibrary1 / steamapps / common / Hexen
+
+            var gameStoreFiles = StoreGameLoader.LoadAllStoreGames(new List<GameFinder>() { FindHexenGame });
+
+            var iwads = gameStoreFiles.InstalledIWads;
+
+            // Heretic + Hexen is higher priority, and should get picked up instead of Hexen
+            Assert.IsTrue(iwads.Exists(x => x.Contains("Resources\\TestSteamLibrary1\\steamapps\\common\\TestHereticHexen\\hexen.wad")));
+            Assert.IsFalse(iwads.Exists(x => x.Contains("Resources\\TestSteamLibrary1\\steamapps\\common\\TestHexen\\hexen.wad")));
+        }
+
+        [TestMethod]
         public void LoadFromPath_ReturnsEmptyFilesIfDirectoryNotFound()
         {
             var gameStoreFiles = StoreGameLoader.LoadStoreGame(StoreGame.ULTIMATE_DOOM, @"Resources\DoesNotExist");
             Assert.AreEqual(gameStoreFiles, GameStoreFiles.EMPTY);
+        }
+
+        private static string FindHexenGame(StoreGame game)
+        {
+            if (game.Equals(StoreGame.HERETIC_PLUS_HEXEN))
+                return $@"Resources\TestSteamLibrary1\steamapps\common\TestHereticHexen";
+            else if (game.Equals(StoreGame.HEXEN))
+                return $@"Resources\TestSteamLibrary1\steamapps\common\TestHexen";
+            else return null;
+
         }
     }
 }

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -244,7 +244,13 @@
     <None Include="Resources\TestSteamLibrary1\steamapps\appmanifest_2280.acf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Resources\TestSteamLibrary1\steamapps\appmanifest_2360.acf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Resources\TestSteamLibrary1\steamapps\appmanifest_2390.acf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Resources\TestSteamLibrary1\steamapps\appmanifest_3286930.acf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Resources\TestSteamLibrary1\steamapps\common\TestDoom\base\doom.wad">
@@ -271,7 +277,13 @@
     <None Include="Resources\TestSteamLibrary1\steamapps\common\TestDoom\rerelease\tnt.wad">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Resources\TestSteamLibrary1\steamapps\common\TestHereticHexen\hexen.wad">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Resources\TestSteamLibrary1\steamapps\common\TestHeretic\base\heretic.wad">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Resources\TestSteamLibrary1\steamapps\common\TestHexen\base\hexen.wad">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Resources\TestSteamLibrary3\steamapps\appmanifest_2360.acf">

--- a/WadReader/DoomImage/PaletteReaders.cs
+++ b/WadReader/DoomImage/PaletteReaders.cs
@@ -17,6 +17,8 @@ namespace WadReader
                     return true;
                 case 320 * 200: // TITLE images use this size
                     return true;
+                case 560 * 200: // Heretic + Hexen TITLE images use this size
+                    return true;
                 default:
                     return false;
             }
@@ -128,6 +130,11 @@ namespace WadReader
             else if (length == 320 * 200)
             {
                 width = 320;
+                height = 200;
+            }
+            else if (length == 560 * 200) // Wide Hexen + Heretic TITLE format
+            {
+                width = 560;
                 height = 200;
             }
             else


### PR DESCRIPTION
Addresses #407, fixing Hexen TITLE images. 

This one was 3 bugs in a trenchcoat:
- The TITLE image from "Hexen" in Steam was displaying strangely, because our code was mistakenly selecting the Heretic palette. This was because the selection logic was checking the IWAD, but `hexen.wad` _is_ the IWAD and doesn't exist yet. Now it can make do with checking the filename base, without the IWAD existing in the DB yet.
- The auto Steam/Gog loader was selecting `hexen.wad` from "Hexen" instead of "Heretic + Hexen", even though H+H is higher priority. This is because the internal structure of H+H has apparently changed since launch, and we were looking for the wads in the wrong place.
- The Heretic + Hexen TITLE lump is super wide. We need to explicitly support 560x200 as a valid image size for a flat.

All fixed now, with a test case added for the auto-load priority ordering. Both the wide and regular images look as you'd expect both in 16:9 and 4:3 aspect ratios.