### PR TITLE
Ignore a GAMEINFO title of 'Supercharge' when syncing

### DIFF
--- a/DoomLauncher/Handlers/Sync/GameInfoSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/GameInfoSyncAction.cs
@@ -21,7 +21,11 @@ namespace DoomLauncher.Handlers.Sync
                 var text = entry.ReadString(Encoding.UTF7);
                 var mapping = ParseGameInfo(text);
 
-                if (mapping.TryGetValue("STARTUPTITLE", out var title) && !string.IsNullOrWhiteSpace(title))
+                if (mapping.TryGetValue("STARTUPTITLE", out var title) 
+                    && !string.IsNullOrWhiteSpace(title)
+                    // Supercharge is a popular gameplay mod that is sometimes shipped inside another wad. 
+                    // In that case, we don't want to override the wad's actual title.
+                    && !title.Equals("Supercharge")) 
                 {
                     gameFile.Title = title;
                 }

--- a/DoomLauncher/Handlers/Sync/GameInfoSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/GameInfoSyncAction.cs
@@ -15,7 +15,7 @@ namespace DoomLauncher.Handlers.Sync
         public SyncResult ApplyToGameFile(IGameFile gameFile, IArchiveReader reader, string[] mapInfoData)
         {
             // Normally it's GAMEINFO, but I've seen GAMEINFO.txt in the wild. 
-            var entry = reader.Entries.FirstOrDefault(x => x.Name.ToLower().StartsWith("gameinfo"));
+            var entry = reader.Entries.LastOrDefault(x => x.Name.ToLower().StartsWith("gameinfo"));
             if (entry != null)
             {
                 var text = entry.ReadString(Encoding.UTF7);

--- a/DoomLauncher/Handlers/Sync/GameInfoSyncAction.cs
+++ b/DoomLauncher/Handlers/Sync/GameInfoSyncAction.cs
@@ -1,9 +1,8 @@
 ﻿using DoomLauncher.Interfaces;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
+
 
 namespace DoomLauncher.Handlers.Sync
 {
@@ -18,7 +17,7 @@ namespace DoomLauncher.Handlers.Sync
             var entry = reader.Entries.LastOrDefault(x => x.Name.ToLower().StartsWith("gameinfo"));
             if (entry != null)
             {
-                var text = entry.ReadString(Encoding.UTF7);
+                var text = entry.ReadString(Encoding.UTF8);
                 var mapping = ParseGameInfo(text);
 
                 if (mapping.TryGetValue("STARTUPTITLE", out var title) 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,6 +6,7 @@
 - "Resync recommended" button so that users can benefit from significant syncing improvements
 - TitlePics are no longer considered screenshots; right click on a screenshot to set as main image
 - Support for wide image title pic in Heretic + Hexen
+- Resyncing is better at deciding the right title
 
 ## Bug Fixes:
 - Upgraded SharpCompress utility to eliminate moderate vulnerability

--- a/UnitTest/Tests/Helpers/Tree.cs
+++ b/UnitTest/Tests/Helpers/Tree.cs
@@ -11,7 +11,7 @@ namespace UnitTest.Tests
         public byte[] Content { get; }
 
         public string ContentString =>
-            Encoding.UTF7.GetString(Content);
+            Encoding.UTF8.GetString(Content);
 
         public List<Tree> Children { get; }
 
@@ -32,7 +32,7 @@ namespace UnitTest.Tests
         public Tree(string name, string content, params Tree[] children)
         {
             Name = name;
-            Content = Encoding.UTF7.GetBytes(content);
+            Content = Encoding.UTF8.GetBytes(content);
             Children = children.ToList();
         }
     }

--- a/UnitTest/Tests/TestGameInfoSyncAction.cs
+++ b/UnitTest/Tests/TestGameInfoSyncAction.cs
@@ -27,6 +27,26 @@ namespace UnitTest.Tests
         }
 
         [TestMethod]
+        public void ApplyToGameFile_FindsTitleInTheLastGAMEINFO()
+        {
+            var gameFile = new GameFile()
+            {
+                FileName = "blah.wad"
+            };
+
+            var syncAction = new GameInfoSyncAction();
+
+            Tree files = new Tree("root", 
+                new Tree("GAMEINFO", "STARTUPTITLE  = \"Wrong answer\""),
+                new Tree("GAMEINFO.real", "STARTUPTITLE  = \"Right answer\""));
+            var reader = new TreeReader(files);
+
+            var result = syncAction.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.AreEqual("Right answer", gameFile.Title);
+        }
+
+        [TestMethod]
         public void ApplyToGameFile_IgnoresSuperchargeTitleInGAMEINFO()
         {
             var gameFile = new GameFile()

--- a/UnitTest/Tests/TestGameInfoSyncAction.cs
+++ b/UnitTest/Tests/TestGameInfoSyncAction.cs
@@ -27,6 +27,24 @@ namespace UnitTest.Tests
         }
 
         [TestMethod]
+        public void ApplyToGameFile_IgnoresSuperchargeTitleInGAMEINFO()
+        {
+            var gameFile = new GameFile()
+            {
+                FileName = "blah.wad"
+            };
+
+            var syncAction = new GameInfoSyncAction();
+
+            Tree files = new Tree("root", new Tree("GAMEINFO", "IWAD = \"blah.wad\"\nSTARTUPTITLE  = \"Supercharge\"\nSOMETHING_ELSE = blah"));
+            var reader = new TreeReader(files);
+
+            var result = syncAction.ApplyToGameFile(gameFile, reader, new string[0]);
+
+            Assert.IsTrue(string.IsNullOrEmpty(gameFile.Title));
+        }
+
+        [TestMethod]
         public void ApplyToGameFile_FindsIntendedGameInGAMEINFO()
         {
             var gameFile = new GameFile()


### PR DESCRIPTION
Addresses https://github.com/nstlaurent/DoomLauncher/issues/412

- `GameInfoSyncAction` specially ignores a `STARTUPTITLE` of "Supercharge"
- Test case confirms
- Cacoward winners "Godless Night" and "Brotherhood of Ruin" both get the correct titles synced now
- The Supercharge gameplay mod itself still syncs with a title of "Supercharge"

