### PR TITLE
Resync recommended button disables when you press it

### DIFF
--- a/DoomLauncher/Forms/MainForm.cs
+++ b/DoomLauncher/Forms/MainForm.cs
@@ -1188,6 +1188,7 @@ namespace DoomLauncher
 
         private async void btnSyncRecommended_Click(object sender, EventArgs e)
         {
+            btnSyncRecommended.Enabled = false;
             await SyncGameFilesThatNeedSync();
             btnSyncRecommended.Visible = false;
         }


### PR DESCRIPTION
Addresses #411

When you press the Resync Recommended button, it will disable the button first before starting the sync. 

I also tried & failed make the following work:
- Making it a modal dialog with `ShowDialog`. This produced strange behaviour and did not show or advance the progress bar. I didn't have the patience to work through it. 
- Setting MainForm.Enabled = false. This looks terrible in dark mode, because the description text box in the side panel has a white background when disabled. As far as I can tell, there's not much you can do to restyle disabled components.