### PR TITLE
Adding the first source port will also make it the default source port

### DIFF
--- a/DoomLauncher/Adapters/DbDataSourceAdapter.cs
+++ b/DoomLauncher/Adapters/DbDataSourceAdapter.cs
@@ -368,6 +368,12 @@ namespace DoomLauncher
                 return obj;
         }
 
+        public int GetSourcePortCount()
+        {
+            DataTable dt = DataAccess.ExecuteSelect("select count(*) from SourcePorts where Archived = 0").Tables[0];
+            return Convert.ToInt32(dt.Rows[0][0]);
+        }
+
         public ISourcePortData GetSourcePort(int sourcePortID)
         {
             DataTable dt = DataAccess.ExecuteSelect(string.Format("select * from SourcePorts where SourcePortID = {0}", sourcePortID)).Tables[0];

--- a/DoomLauncher/Config/AppConfiguration.cs
+++ b/DoomLauncher/Config/AppConfiguration.cs
@@ -41,6 +41,8 @@ namespace DoomLauncher
         public static string TileImageSizeName => "TileImageSize";
         public static string TileImageAspectRatioName => "TileImageAspectRatio";
 
+        public static string DefaultSourcePort => "DefaultSourcePort";
+
         public AppConfiguration(IDataSourceAdapter adapter)
         {
             DataSourceAdapter = adapter;

--- a/DoomLauncher/Forms/SourcePortViewForm.cs
+++ b/DoomLauncher/Forms/SourcePortViewForm.cs
@@ -156,7 +156,15 @@ namespace DoomLauncher
                 SourcePortData sourcePort = new SourcePortData();
                 editForm.UpdateDataSource(sourcePort);
                 sourcePort.LaunchType = m_launchType;
+
+                int existingSourcePortCount = m_adapter.GetSourcePortCount();
                 m_adapter.InsertSourcePort(sourcePort);
+
+                if (existingSourcePortCount == 0)
+                {
+                    DataCache.Instance.UpdateConfig(m_adapter.GetConfiguration(), AppConfiguration.DefaultSourcePort, sourcePort.SourcePortID.ToString());
+                }
+
                 ResetData();
 
                 SelectSourcePort(sourcePort);

--- a/DoomLauncher/Interfaces/IDataSourceAdapter.cs
+++ b/DoomLauncher/Interfaces/IDataSourceAdapter.cs
@@ -12,6 +12,7 @@ namespace DoomLauncher.Interfaces
 
         IEnumerable<ISourcePortData> GetDoom64(bool loadArchived = false);
 
+        int GetSourcePortCount(); // Excluding archived
         ISourcePortData GetSourcePort(int sourcePortID);
         void InsertSourcePort(ISourcePortData sourcePort);
         void UpdateSourcePort(ISourcePortData sourcePort);

--- a/UnitTest/Tests/TestSourcePort.cs
+++ b/UnitTest/Tests/TestSourcePort.cs
@@ -1,4 +1,5 @@
 ﻿using DoomLauncher;
+using DoomLauncher.DataSources;
 using DoomLauncher.Interfaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
@@ -46,6 +47,7 @@ namespace UnitTest.Tests
         public void TestSourcePortData()
         {
             Clear();
+            TestGetSourcePortCount();
             TestInsert();
             TestGetSourcePorts();
             TestUpdate();
@@ -85,6 +87,19 @@ namespace UnitTest.Tests
                 var port = allSourcePorts.First(x => x.Name.Equals(testSourcePort.Name));
                 Assert.IsTrue(TestUtil.AllFieldsEqualIgnore(testSourcePort, port, nameof(ISourcePortData.SourcePortID)));
             }
+        }
+
+        public void TestGetSourcePortCount()
+        {
+            IDataSourceAdapter adapter = TestUtil.CreateAdapter();
+            Assert.AreEqual(0, adapter.GetSourcePortCount());
+
+            var sourcePort = new SourcePortData() { Name = "Some source port" };
+            adapter.InsertSourcePort(sourcePort);
+            Assert.AreEqual(1, adapter.GetSourcePortCount());
+
+            adapter.DeleteSourcePort(sourcePort);
+            Assert.AreEqual(0, adapter.GetSourcePortCount());
         }
 
         public void TestGetSourcePort()


### PR DESCRIPTION
Conservative, minimal fix addressing #406

- When a source port is added through the SourcePortViewForm, then if it is the first one added, it will make it the default source port
- Slightly simplifies onboarding for new users
- If the default source port is deleted, then avoids the situation where all the wads that had that source port saved end up with a blank space in the Play Form
- New database method GetSourcePortCount, mirroring GetGameFileCount (but ignores archived source ports)
- Database method is tested, but as usual, UI flow is not
- I might do more work on the onboarding flow for the next version, and would likely do some refactoring to suck some testable logic out of the UI, but this will do for this version I think
